### PR TITLE
Adding a final gather of logs after completion

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -163,6 +163,12 @@ public class AnsibleTowerRunner {
                 }
             }
         }
+        try {
+            myTowerConnection.logEvents(myJobID, templateType, importWorkflowChildLogs);
+        } catch(AnsibleTowerException e) {
+            logger.println("ERROR: Failed to get job events from tower: "+ e.getMessage());
+            return false;
+        }
 
         HashMap<String, String> jenkinsVariables = myTowerConnection.getJenkinsExports();
         for(Map.Entry<String, String> entrySet : jenkinsVariables.entrySet()) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -166,7 +166,7 @@ public class AnsibleTowerRunner {
         try {
             myTowerConnection.logEvents(myJobID, templateType, importWorkflowChildLogs);
         } catch(AnsibleTowerException e) {
-            logger.println("ERROR: Failed to get job events from tower: "+ e.getMessage());
+            logger.println("ERROR: Failed to get final job events from tower: "+ e.getMessage());
             return false;
         }
 


### PR DESCRIPTION
Oftentimes, the tower log is truncated once the job is completed, especially with particularly long running jobs. This will allow the tower connector to gather the logs after job completion.

Addresses https://github.com/john-westcott-iv/ansible-tower/issues/3