### PR TITLE
[JENKINS-51009] Remove misleading compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
                     <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                    <compatibleSinceVersion>1.8.17</compatibleSinceVersion>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The compatibility check is not correct here, as this version doesn't yet exist.