### PR TITLE
Decrease EnvInject plugin release to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject</artifactId>
-            <version>2.1.5</version>
+            <version>2.1.3</version>
             <optional>true</optional>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->


### PR DESCRIPTION
Due to these 2 issues, [JENKINS-47364 ](https://issues.jenkins-ci.org/browse/JENKINS-47364)and [JENKINS-47370](https://issues.jenkins-ci.org/browse/JENKINS-47370), created on the Environment Injector plugin 2.1.4 release, the highest release of this plugin to be used is the 2.1.3 one.