### PR TITLE
fix bugs in issues.jenkins-ci.org JENKINS-60352 does not pass credentials from job to Ansible tower

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>ansible-tower</artifactId>
-    <version>0.13.1-SNAPSHOT</version>
+    <version>0.13.1-Scotiabank</version>
     <packaging>hpi</packaging>
     <name>Ansible Tower Plugin</name>
     <description>

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -514,8 +514,8 @@ public class TowerConnector implements Serializable {
             postBody.put("credentials", allCredentials);
         } else {
             // We need to pass individual fields
-            if(credentials.get("machine").size() > 0) { postBody.put("credential", credentials.get("machine").get(0)); }
-            if(credentials.get("vault").size() > 0) { postBody.put("vault_credential", credentials.get("vault").get(0)); }
+            if(credentials.get("machine").size() > 0) { postBody.put("credentials", credentials.get("machine")); }
+            if(credentials.get("vault").size() > 0) { postBody.put("vault_credential", credentials.get("vault")); }
             if(credentials.get("extra").size() > 0) {
                 JSONArray extraCredentials = new JSONArray();
                 extraCredentials.addAll(credentials.get("extra"));


### PR DESCRIPTION
fix bugs in issues.jenkins-ci.org For Bug -- JENKINS-60352 
Details: Ansible Tower Plugin does not pass credentials from job to Ansible tower