### PR TITLE
scmBranch expanded to expandedScmBranch but not used

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -203,7 +203,7 @@ public class AnsibleTowerRunner {
         }
 
         try {
-            this.myJob.setJobId(myTowerConnection.submitTemplate(template.getInt("id"), expandedExtraVars, expandedLimit, expandedJobTags, expandedSkipJobTags, jobType, expandedInventory, expandedCredential, scmBranch, templateType));
+            this.myJob.setJobId(myTowerConnection.submitTemplate(template.getInt("id"), expandedExtraVars, expandedLimit, expandedJobTags, expandedSkipJobTags, jobType, expandedInventory, expandedCredential, expandedScmBranch, templateType));
         } catch (AnsibleTowerException e) {
             logger.println("ERROR: Unable to request job template invocation " + e.getMessage());
             myTowerConnection.releaseToken();


### PR DESCRIPTION
The scmBranch variable is expanded to expandedScmBranch but not used when setting the job parameters. This makes running the job in Ansible Tower with the variable name instead of the variable value.