### PR TITLE
Stop setting `pluginFirstClassLoader`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <minimumJavaVersion>1.8</minimumJavaVersion>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>1.8</source>


### PR DESCRIPTION
As far as I can tell, this plugin doesn't need it, and it is explicitly not recommended.