### PR TITLE
Use UTF-8 to encode StringEntity

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -174,12 +174,8 @@ public class TowerConnector implements Serializable {
                 myRequest = new HttpPatch(myURI);
             }
             if (body != null && !body.isEmpty()) {
-                try {
-                    StringEntity bodyEntity = new StringEntity(body.toString());
-                    myRequest.setEntity(bodyEntity);
-                } catch (UnsupportedEncodingException uee) {
-                    throw new AnsibleTowerException("Unable to encode body as JSON: " + uee.getMessage());
-                }
+                StringEntity bodyEntity = new StringEntity(body.toString(),"UTF-8");
+                myRequest.setEntity(bodyEntity);
             }
             request = myRequest;
             request.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
When charset is not set for StringEntity it defaults to iso-8859-1, since we set it already to UTF-8 in getHttpClient this should be fine
