### PR TITLE
fix the returned URL for workflow: bug JENKINS-69378

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -1045,7 +1045,7 @@ public class TowerConnector implements Serializable {
         if (templateType.equalsIgnoreCase(TowerConnector.JOB_TEMPLATE_TYPE)) {
             returnURL += "jobs";
         } else {
-            returnURL += "workflows";
+            returnURL += "jobs/workflow";
         }
         returnURL += "/"+ myJobID;
         return returnURL;


### PR DESCRIPTION
Fixing the returned URL for workflow jobs. This is achieved by changing the returnURL in TowerConnector.java getJobURL method to match URL from AWX.
Please note this was NOT tested as I could not mvn build successfully (even without this modification). 

https://issues.jenkins.io/browse/JENKINS-69378

<!-- Please describe your pull request here. -->

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [n/a ] Link to relevant pull requests, esp. upstream and downstream changes
- [- ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
