### PR TITLE
Fix infinite hanging deploy on Jenkins job and more in general Ansible Tower api json id conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 .settings/
 .java-version
 src/test
+
+#VSCODE IDE
+.vscode/

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -203,7 +203,7 @@ public class AnsibleTowerRunner {
         }
 
         try {
-            this.myJob.setJobId(myTowerConnection.submitTemplate(template.getInt("id"), expandedExtraVars, expandedLimit, expandedJobTags, expandedSkipJobTags, jobType, expandedInventory, expandedCredential, expandedScmBranch, templateType));
+            this.myJob.setJobId(myTowerConnection.submitTemplate(template.getLong("id"), expandedExtraVars, expandedLimit, expandedJobTags, expandedSkipJobTags, jobType, expandedInventory, expandedCredential, expandedScmBranch, templateType));
         } catch (AnsibleTowerException e) {
             logger.println("ERROR: Unable to request job template invocation " + e.getMessage());
             myTowerConnection.releaseToken();
@@ -213,7 +213,7 @@ public class AnsibleTowerRunner {
         String jobURL = myTowerConnection.getJobURL(this.myJob.getJobID(), templateType);
         logger.println("Template Job URL: " + jobURL);
 
-        towerResults.put("JOB_ID", Integer.toString(this.myJob.getJobID()));
+        towerResults.put("JOB_ID", Long.toString(this.myJob.getJobID()));
         towerResults.put("JOB_URL", jobURL);
 
         if (async) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerJob.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerJob.java
@@ -7,7 +7,7 @@ import java.util.Vector;
 import java.io.Serializable;
 
 public class TowerJob  implements Serializable {
-    private int jobId = -1;
+    private long jobId = -1;
     private TowerConnector connection;
     private String templateType = null;
     private static final long serialVersionUID = -323790358606407805L;
@@ -22,34 +22,34 @@ public class TowerJob  implements Serializable {
         }
         this.templateType = templateType;
     }
-    public void setJobId(Integer jobId) { this.jobId = jobId; }
-    public Integer getJobID() { return this.jobId; }
+    public void setJobId(long jobId) { this.jobId = jobId; }
+    public long getJobID() { return this.jobId; }
 
     @SuppressWarnings("unused")
     public boolean isComplete() throws AnsibleTowerException {
-        if(this.jobId == -1) { throw new AnsibleTowerException("Job ID was not set"); }
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
         return connection.isJobCompleted(this.jobId, this.templateType);
     }
 
     @SuppressWarnings("unused")
     public boolean wasSuccessful() throws AnsibleTowerException {
-        if(this.jobId == -1) { throw new AnsibleTowerException("Job ID was not set"); }
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
         return !connection.isJobFailed(this.jobId, this.templateType);
     }
 
     @SuppressWarnings("unused")
     public Vector<String> getLogs() throws AnsibleTowerException {
-        if(this.jobId == -1) { throw new AnsibleTowerException("Job ID was not set"); }
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
         return this.connection.getLogEvents(this.jobId, this.templateType);
     }
 
     public HashMap<String, String> getExports() throws AnsibleTowerException {
-        if(this.jobId == -1) { throw new AnsibleTowerException("Job ID was not set"); }
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
         return this.connection.getJenkinsExports();
     }
 
     public void cancelJob() throws AnsibleTowerException {
-        if(this.jobId == -1) { throw new AnsibleTowerException("Job ID was not set"); }
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
         this.connection.cancelJob(this.jobId, this.templateType);
         this.connection.releaseToken();
     }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProjectSync.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProjectSync.java
@@ -14,7 +14,7 @@ public class TowerProjectSync implements Serializable {
     private TowerConnector connection = null;
     private TowerProject projectReference = null;
     private JSONObject syncData = null;
-    private int lastLogId = 0;
+    private long lastLogId = 0L;
 
     public TowerProjectSync(TowerConnector connection, TowerProject projectReference) throws AnsibleTowerException {
         this.connection = connection;
@@ -90,7 +90,7 @@ public class TowerProjectSync implements Serializable {
                 }
                 if (responseObject.containsKey("results")) {
                     for (Object anEvent : responseObject.getJSONArray("results")) {
-                        Integer eventId = ((JSONObject) anEvent).getInt("id");
+                        long eventId = ((JSONObject) anEvent).getLong("id");
                         String stdOut = ((JSONObject) anEvent).getString("stdout");
                         events.addAll(connection.logLine(stdOut));
                         if (eventId > this.lastLogId) { this.lastLogId = eventId; }
@@ -114,11 +114,11 @@ public class TowerProjectSync implements Serializable {
     }
 
     public String getURL() {
-        return connection.getURL() +"/#/jobs/project/"+ syncData.getInt("id");
+        return connection.getURL() +"/#/jobs/project/"+ syncData.getLong("id");
     }
 
-    public Integer getID() {
-        return syncData.getInt("id");
+    public long getID() {
+        return syncData.getLong("id");
     }
 
     public void releaseToken() throws AnsibleTowerException {


### PR DESCRIPTION
This PR fixes an issue that makes jenkins job infinetely waiting for Ansible Tower deploy to complete, even if process on Tower is completed for real.

The code responsible for this kind of behaviour is this:
https://github.com/jenkinsci/ansible-tower-plugin/blob/1800289287bdb1eee157a15fdffa8675ea010e4c/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java#L968-L1014

the issue is due the looping logic that never ends while collecting job events logs using the api `/job/[jobID]/job_events/?id__gt=[eventID]` where `id__gt` parameter is used for  handling pagination (instead of relying on json `next` field).

In the mentioned logic, the `eventID` parsed from the json as an Integer (at `line 994` of the refereced code) goes in overflow in case `eventID` is greather then `Integer.MAX_VALUE` (2^31-1 = 2147483647), producing a negative integer and thus failing the update to the latest `eventId` (at `line 1004` of referenced code) producing an infinite loop.

More in general, considering that any kind of id obtained by Ansible Tower api (template id, job id, event id, etc...) could be greather then `Integer.MAX_VALUE` and that current plugin implementation parses all of them as Integer, **this patch tries to overcome the general problem by replacing any Integer conversion with Long conversion without impacting any logic**. This fix the manifested issue but also avoid potential issues on all the api calls invoked by the plugin, where those ids are used.

As a side note and future improvement, pagination logic in the referenced code could be reengineered making use of the `next` field instead of relying on the side effect that `eventId` generated by Ansible Tower are progressive numbers.


### Testing done

Created a freestyle job on Jenkins and configuring Ansible Tower plugin (v0.16.0), with all logging features enabled.

On current version, with an Ansible Tower instance that generate event_id greather than 2147483647, the Jenkins job keeps running forever even if Ansible Tower job has been completed.

Repeating the same test using the patched version, the Jenkins job terminate without issue.


### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

