### PR TITLE
Add AAP 2.5+ controller compatibility to Ansible Tower plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ The fields are as follows:
 | Force Trust Cert | If your Ansible Tower instance is using an https cert that Jenkins does not trust, and you want the plugin to trust the cert anyway, you can click this box.<br/><br/>You should really understand the implications if you are going to use this option. Its meant for testing purposes only. |
 | Name | The name that this Ansible Tower installation will be referenced as. |
 | URL | The base URL used for API calls to the Ansible Tower, AWX, or AAP controller.|
-| Display URL | Optional base URL used when Jenkins prints links to the controller UI. Leave blank to use URL. Set this when an AAP gateway/API URL and controller UI URL are different.|
 | API Base Path | API path used for controller API calls. Use `/api/v2` for Tower/AWX legacy installations. Use `/api/controller/v2` for AAP 2.5+ controller deployments.|
+
+Display URL is optional and is used only when Jenkins prints links to the controller UI. Leave it blank to use URL. Set it when an AAP gateway/API URL and controller UI URL are different.
 
 Once the settings are completed, you can test the connection between Jenkins and Ansible Tower by clicking on the Test Connection button.
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Once the settings are completed, you can test the connection between Jenkins and
 
 Existing Pipeline steps and Freestyle build steps remain unchanged. Jobs that already use `ansibleTower`, `ansibleTowerProjectSync`, or `ansibleTowerProjectRevision` do not need to be renamed.
 
-For AAP 2.5+ controller deployments, configure the installation with:
+For AAP 2.5+ controller deployments, configure the installation like this:
 
-| Field | Example |
-|-------|---------|
-| URL | `https://aap-gateway.example.com` |
-| Display URL | `https://aap-controller.example.com` |
-| API Base Path | `/api/controller/v2` |
+```text
+URL: https://aap-gateway.example.com
+Display URL: https://aap-controller.example.com
+API Base Path: /api/controller/v2
+```
 
 When API Base Path is set to `/api/controller/v2`, generated job links use AAP Controller execution output URLs such as:
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,33 @@ The fields are as follows:
 | Enable Debugging | This will allow the plugin to write detailed messages into the jenkins.log for debugging purposes. It will show show requests to the server and payloads. This can contain a lot of data. All messages are prefixed with \[Ansible-Tower].<br/><br/>For Example:<br/><br/>[Ansible-Tower] building request to https://192.168.56.101/api/v1/workflow_jobs/200/workflow_nodes/<br/>[Ansible-Tower] Adding auth for admin<br/>[Ansible-Tower] Forcing cert trust</br> [Ansible-Tower] {"count":4,"next":null ...</br>|
 | Force Trust Cert | If your Ansible Tower instance is using an https cert that Jenkins does not trust, and you want the plugin to trust the cert anyway, you can click this box.<br/><br/>You should really understand the implications if you are going to use this option. Its meant for testing purposes only. |
 | Name | The name that this Ansible Tower installation will be referenced as. |
-| URL | The base URL of the Ansible Tower server.|
+| URL | The base URL used for API calls to the Ansible Tower, AWX, or AAP controller.|
+| Display URL | Optional base URL used when Jenkins prints links to the controller UI. Leave blank to use URL. Set this when an AAP gateway/API URL and controller UI URL are different.|
+| API Base Path | API path used for controller API calls. Use `/api/v2` for Tower/AWX legacy installations. Use `/api/controller/v2` for AAP 2.5+ controller deployments.|
 
 Once the settings are completed, you can test the connection between Jenkins and Ansible Tower by clicking on the Test Connection button.
+
+## AAP 2.5+ Compatibility
+
+Existing Pipeline steps and Freestyle build steps remain unchanged. Jobs that already use `ansibleTower`, `ansibleTowerProjectSync`, or `ansibleTowerProjectRevision` do not need to be renamed.
+
+For AAP 2.5+ controller deployments, configure the installation with:
+
+| Field | Example |
+|-------|---------|
+| URL | `https://aap-gateway.example.com` |
+| Display URL | `https://aap-controller.example.com` |
+| API Base Path | `/api/controller/v2` |
+
+When API Base Path is set to `/api/controller/v2`, generated job links use AAP Controller execution output URLs such as:
+
+```text
+https://aap-controller.example.com/execution/jobs/playbook/123/output
+https://aap-controller.example.com/execution/jobs/workflow/456/output
+https://aap-controller.example.com/execution/jobs/project_update/789/output
+```
+
+If Display URL is blank, the configured URL is used for both API calls and UI links.
 
 ## Basic Authentication
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -198,6 +198,39 @@ public class TowerConnector implements Serializable {
         return normalizeBaseURL(url);
     }
 
+    static boolean isAAPControllerMode(String apiBasePath) {
+        return API_BASE_PATH_AAP_CONTROLLER.equals(normalizeApiBasePath(apiBasePath));
+    }
+
+    static String buildJobURL(String uiBaseURL, String apiBasePath, long jobID, String templateType) {
+        uiBaseURL = normalizeBaseURL(uiBaseURL);
+        if(isAAPControllerMode(apiBasePath)) {
+            String jobPath = JOB_TEMPLATE_TYPE;
+            if(WORKFLOW_TEMPLATE_TYPE.equalsIgnoreCase(templateType)) {
+                jobPath = "workflow";
+            } else {
+                jobPath = "playbook";
+            }
+            return uiBaseURL + "/execution/jobs/" + jobPath + "/" + jobID + "/output";
+        }
+
+        String returnURL = uiBaseURL +"/#/";
+        if (JOB_TEMPLATE_TYPE.equalsIgnoreCase(templateType)) {
+            returnURL += "jobs";
+        } else {
+            returnURL += "workflows";
+        }
+        return returnURL + "/" + jobID;
+    }
+
+    static String buildProjectSyncURL(String uiBaseURL, String apiBasePath, long syncID) {
+        uiBaseURL = normalizeBaseURL(uiBaseURL);
+        if(isAAPControllerMode(apiBasePath)) {
+            return uiBaseURL + "/execution/jobs/project_update/" + syncID + "/output";
+        }
+        return uiBaseURL + "/#/jobs/project/" + syncID;
+    }
+
     private HttpResponse makeRequest(int requestType, String endpoint) throws AnsibleTowerException {
         return makeRequest(requestType, endpoint, null, false);
     }
@@ -1097,14 +1130,11 @@ public class TowerConnector implements Serializable {
     }
 
     public String getJobURL(long myJobID, String templateType) {
-        String returnURL = getUIBaseURL() +"/#/";
-        if (templateType.equalsIgnoreCase(TowerConnector.JOB_TEMPLATE_TYPE)) {
-            returnURL += "jobs";
-        } else {
-            returnURL += "workflows";
-        }
-        returnURL += "/"+ myJobID;
-        return returnURL;
+        return buildJobURL(getUIBaseURL(), this.apiBasePath, myJobID, templateType);
+    }
+
+    public String getProjectSyncURL(long syncID) {
+        return buildProjectSyncURL(getUIBaseURL(), this.apiBasePath, syncID);
     }
 
     private String getBasicAuthString() {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -47,13 +47,15 @@ public class TowerConnector implements Serializable {
     public static final int PATCH = 3;
     public static final String JOB_TEMPLATE_TYPE = "job";
     public static final String WORKFLOW_TEMPLATE_TYPE = "workflow";
+    public static final String API_BASE_PATH_LEGACY = "/api/v2";
+    public static final String API_BASE_PATH_AAP_CONTROLLER = "/api/controller/v2";
     private static final String ARTIFACTS = "artifacts";
-    private static String API_VERSION = "v2";
 
     private String authorizationHeader = null;
     private String oauthToken = null;
     private String oAuthTokenID = null;
     private String url = null;
+    private String apiBasePath = API_BASE_PATH_LEGACY;
     private String username = null;
     private String password = null;
     private TowerVersion towerVersion = null;
@@ -70,11 +72,12 @@ public class TowerConnector implements Serializable {
     public TowerConnector(String url, String username, String password) { this(url, username, password, null, false, false); }
 
     public TowerConnector(String url, String username, String password, String oauthToken, Boolean trustAllCerts, Boolean debug) {
-        // Credit to https://stackoverflow.com/questions/7438612/how-to-remove-the-last-character-from-a-string
-        if(url != null && url.length() > 0 && url.charAt(url.length() - 1) == '/') {
-            url = url.substring(0, (url.length() - 1));
-        }
-        this.url = url;
+        this(url, username, password, oauthToken, trustAllCerts, debug, API_BASE_PATH_LEGACY);
+    }
+
+    public TowerConnector(String url, String username, String password, String oauthToken, Boolean trustAllCerts, Boolean debug, String apiBasePath) {
+        this.url = normalizeBaseURL(url);
+        this.apiBasePath = normalizeApiBasePath(apiBasePath);
         this.username = username;
         this.password = password;
         this.oauthToken = oauthToken;
@@ -99,6 +102,30 @@ public class TowerConnector implements Serializable {
     public void setGetWorkflowChildLogs(boolean importChildWorkflowLogs) { this.importChildWorkflowLogs = importChildWorkflowLogs; }
     public void setGetFullLogs(boolean getFullLogs) { this.getFullLogs = getFullLogs; }
     public HashMap<String, String> getJenkinsExports() { return jenkinsExports; }
+
+    static String normalizeBaseURL(String baseURL) {
+        if(baseURL != null) {
+            baseURL = baseURL.trim();
+            if(baseURL.length() > 0 && baseURL.charAt(baseURL.length() - 1) == '/') {
+                baseURL = baseURL.substring(0, (baseURL.length() - 1));
+            }
+        }
+        return baseURL;
+    }
+
+    static String normalizeApiBasePath(String apiBasePath) {
+        if(apiBasePath == null || apiBasePath.trim().isEmpty()) {
+            return API_BASE_PATH_LEGACY;
+        }
+        apiBasePath = apiBasePath.trim();
+        if(!apiBasePath.startsWith("/")) {
+            apiBasePath = "/" + apiBasePath;
+        }
+        if(apiBasePath.endsWith("/")) {
+            apiBasePath = apiBasePath.substring(0, apiBasePath.length() - 1);
+        }
+        return apiBasePath;
+    }
 
     private DefaultHttpClient getHttpClient() throws AnsibleTowerException {
         URI myURI = null;
@@ -136,9 +163,13 @@ public class TowerConnector implements Serializable {
     }
 
     private String buildEndpoint(String endpoint) {
+        return buildEndpoint(endpoint, this.apiBasePath);
+    }
+
+    static String buildEndpoint(String endpoint, String apiBasePath) {
         if(endpoint.startsWith("/api/")) { return endpoint; }
 
-        String full_endpoint = "/api/"+ API_VERSION;
+        String full_endpoint = normalizeApiBasePath(apiBasePath);
         if(!endpoint.startsWith("/")) { full_endpoint += "/"; }
         full_endpoint += endpoint;
         return full_endpoint;
@@ -211,7 +242,7 @@ public class TowerConnector implements Serializable {
                     }
 
                     // Second, we will try to get a legacy authtoken if Tower supports if
-                    if(this.authorizationHeader == null && this.towerSupports("/api/v2/authtoken")) {
+                    if(this.authorizationHeader == null && this.towerSupports(this.buildEndpoint("/authtoken/"))) {
                         logger.logMessage("Getting a legacy token for " + this.username);
                         try {
                             this.authorizationHeader = "Token " + this.getAuthToken();

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -49,11 +49,13 @@ public class TowerConnector implements Serializable {
     public static final String WORKFLOW_TEMPLATE_TYPE = "workflow";
     public static final String API_BASE_PATH_LEGACY = "/api/v2";
     public static final String API_BASE_PATH_AAP_CONTROLLER = "/api/controller/v2";
+    public static final String API_GATEWAY_TOKEN_ENDPOINT = "/api/gateway/v1/tokens/";
     private static final String ARTIFACTS = "artifacts";
 
     private String authorizationHeader = null;
     private String oauthToken = null;
     private String oAuthTokenID = null;
+    private String oAuthTokenBaseEndpoint = null;
     private String url = null;
     private String apiBasePath = API_BASE_PATH_LEGACY;
     private String username = null;
@@ -173,6 +175,13 @@ public class TowerConnector implements Serializable {
         if(!endpoint.startsWith("/")) { full_endpoint += "/"; }
         full_endpoint += endpoint;
         return full_endpoint;
+    }
+
+    static String buildOAuthTokenEndpoint(String apiBasePath) {
+        if(API_BASE_PATH_AAP_CONTROLLER.equals(normalizeApiBasePath(apiBasePath))) {
+            return API_GATEWAY_TOKEN_ENDPOINT;
+        }
+        return buildEndpoint("/tokens/", apiBasePath);
     }
 
     private HttpResponse makeRequest(int requestType, String endpoint) throws AnsibleTowerException {
@@ -1089,7 +1098,8 @@ public class TowerConnector implements Serializable {
     }
 
     private String getOAuthToken() throws AnsibleTowerException {
-        String tokenURI = url + this.buildEndpoint("/tokens/");
+        String tokenEndpoint = buildOAuthTokenEndpoint(this.apiBasePath);
+        String tokenURI = url + tokenEndpoint;
         HttpPost oauthTokenRequest = new HttpPost(tokenURI);
         oauthTokenRequest.setHeader(HttpHeaders.AUTHORIZATION, this.getBasicAuthString());
         JSONObject body = new JSONObject();
@@ -1135,6 +1145,7 @@ public class TowerConnector implements Serializable {
 
         if (responseObject.containsKey("id")) {
             this.oAuthTokenID = responseObject.getString("id");
+            this.oAuthTokenBaseEndpoint = tokenEndpoint;
         }
 
         if (responseObject.containsKey("token")) {
@@ -1201,7 +1212,11 @@ public class TowerConnector implements Serializable {
         if(this.oAuthTokenID != null) {
             logger.logMessage("Deleting oAuth token "+ this.oAuthTokenID +" for " + this.username);
             try {
-                String tokenURI = url + this.buildEndpoint("/tokens/" + this.oAuthTokenID + "/");
+                String tokenEndpoint = this.oAuthTokenBaseEndpoint;
+                if(tokenEndpoint == null) {
+                    tokenEndpoint = this.buildEndpoint("/tokens/");
+                }
+                String tokenURI = url + tokenEndpoint + this.oAuthTokenID + "/";
                 HttpDelete tokenRequest = new HttpDelete(tokenURI);
                 tokenRequest.setHeader(HttpHeaders.AUTHORIZATION, this.getBasicAuthString());
 
@@ -1216,6 +1231,7 @@ public class TowerConnector implements Serializable {
                 logger.logMessage("oAuth Token deleted");
 
                 this.oAuthTokenID = null;
+                this.oAuthTokenBaseEndpoint = null;
                 this.authorizationHeader = null;
             } catch(Exception e) {
                 logger.logMessage("Failed to delete token: "+ e.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -202,6 +202,10 @@ public class TowerConnector implements Serializable {
         return API_BASE_PATH_AAP_CONTROLLER.equals(normalizeApiBasePath(apiBasePath));
     }
 
+    static boolean shouldProbeOAuthSupport(String apiBasePath) {
+        return !isAAPControllerMode(apiBasePath);
+    }
+
     static String buildJobURL(String uiBaseURL, String apiBasePath, long jobID, String templateType) {
         uiBaseURL = normalizeBaseURL(uiBaseURL);
         if(isAAPControllerMode(apiBasePath)) {
@@ -287,8 +291,8 @@ public class TowerConnector implements Serializable {
                 } else if(this.username != null && this.password != null) {
                     // Second, if we have a username and a password we can try to go get a token
 
-                    // For trying to get a token, we will first attempt to self create an oAuthToken if Tower supports it
-                    if (this.towerSupports("/api/o/")) {
+                    // AAP controller mode uses the gateway token endpoint directly. Legacy Tower/AWX still probes /api/o/.
+                    if (!shouldProbeOAuthSupport(this.apiBasePath) || this.towerSupports("/api/o/")) {
                         logger.logMessage("Getting an oAuth token for "+ this.username);
                         try {
                             this.authorizationHeader = "Bearer " + this.getOAuthToken();

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -57,6 +57,7 @@ public class TowerConnector implements Serializable {
     private String oAuthTokenID = null;
     private String oAuthTokenBaseEndpoint = null;
     private String url = null;
+    private String displayURL = null;
     private String apiBasePath = API_BASE_PATH_LEGACY;
     private String username = null;
     private String password = null;
@@ -78,7 +79,12 @@ public class TowerConnector implements Serializable {
     }
 
     public TowerConnector(String url, String username, String password, String oauthToken, Boolean trustAllCerts, Boolean debug, String apiBasePath) {
+        this(url, username, password, oauthToken, trustAllCerts, debug, apiBasePath, null);
+    }
+
+    public TowerConnector(String url, String username, String password, String oauthToken, Boolean trustAllCerts, Boolean debug, String apiBasePath, String displayURL) {
         this.url = normalizeBaseURL(url);
+        this.displayURL = normalizeBaseURL(displayURL);
         this.apiBasePath = normalizeApiBasePath(apiBasePath);
         this.username = username;
         this.password = password;
@@ -182,6 +188,14 @@ public class TowerConnector implements Serializable {
             return API_GATEWAY_TOKEN_ENDPOINT;
         }
         return buildEndpoint("/tokens/", apiBasePath);
+    }
+
+    static String selectUIBaseURL(String url, String displayURL) {
+        displayURL = normalizeBaseURL(displayURL);
+        if(displayURL != null && !displayURL.isEmpty()) {
+            return displayURL;
+        }
+        return normalizeBaseURL(url);
     }
 
     private HttpResponse makeRequest(int requestType, String endpoint) throws AnsibleTowerException {
@@ -384,6 +398,8 @@ public class TowerConnector implements Serializable {
     }
 
     public String getURL() { return url; }
+    public String getUIBaseURL() { return selectUIBaseURL(this.url, this.displayURL); }
+    public boolean hasDisplayURL() { return this.displayURL != null && !this.displayURL.isEmpty(); }
     public void getVersion() throws AnsibleTowerException {
         // The version is housed on the poing page which is openly accessable
         HttpResponse response = makeRequest(GET, "ping/", null, true);
@@ -1081,7 +1097,7 @@ public class TowerConnector implements Serializable {
     }
 
     public String getJobURL(long myJobID, String templateType) {
-        String returnURL = url +"/#/";
+        String returnURL = getUIBaseURL() +"/#/";
         if (templateType.equalsIgnoreCase(TowerConnector.JOB_TEMPLATE_TYPE)) {
             returnURL += "jobs";
         } else {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
@@ -37,16 +37,18 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     private final String towerDisplayName;
     private final String towerURL;
+    private String towerApiBasePath;
     private String towerCredentialsId;
     private final boolean towerTrustCert;
     private final boolean enableDebugging;
     private Run run;
 
     @DataBoundConstructor
-    public TowerInstallation(String towerDisplayName, String towerURL, String towerCredentialsId, boolean towerTrustCert, boolean enableDebugging) {
+    public TowerInstallation(String towerDisplayName, String towerURL, String towerApiBasePath, String towerCredentialsId, boolean towerTrustCert, boolean enableDebugging) {
         this.towerDisplayName = towerDisplayName;
         this.towerCredentialsId = towerCredentialsId;
         this.towerURL = towerURL;
+        this.towerApiBasePath = TowerConnector.normalizeApiBasePath(towerApiBasePath);
         this.towerTrustCert = towerTrustCert;
         this.enableDebugging = enableDebugging;
     }
@@ -57,6 +59,10 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     public String getTowerURL() {
         return this.towerURL;
+    }
+
+    public String getTowerApiBasePath() {
+        return TowerConnector.normalizeApiBasePath(this.towerApiBasePath);
     }
 
     public String getTowerCredentialsId() {
@@ -81,11 +87,16 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     public TowerConnector getTowerConnector() {
         return TowerInstallation.getTowerConnectorStatic(this.towerURL, this.towerCredentialsId, this.towerTrustCert,
-                this.enableDebugging, this.run);
+                this.enableDebugging, this.run, this.getTowerApiBasePath());
     }
 
     public static TowerConnector getTowerConnectorStatic(String towerURL, String towerCredentialsId, boolean trustCert,
                                                          boolean enableDebugging, Run run) {
+        return getTowerConnectorStatic(towerURL, towerCredentialsId, trustCert, enableDebugging, run, TowerConnector.API_BASE_PATH_LEGACY);
+    }
+
+    public static TowerConnector getTowerConnectorStatic(String towerURL, String towerCredentialsId, boolean trustCert,
+                                                         boolean enableDebugging, Run run, String towerApiBasePath) {
         String username = null;
         String password = null;
         String oauth_token = null;
@@ -104,7 +115,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
                 }
             }
         }
-        TowerConnector testConnector = new TowerConnector(towerURL, username, password, oauth_token, trustCert, enableDebugging);
+        TowerConnector testConnector = new TowerConnector(towerURL, username, password, oauth_token, trustCert, enableDebugging, towerApiBasePath);
         return testConnector;
     }
     
@@ -129,6 +140,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
         @POST
         public FormValidation doTestTowerConnection(
                 @QueryParameter("towerURL") final String towerURL,
+                @QueryParameter("towerApiBasePath") final String towerApiBasePath,
                 @QueryParameter("towerCredentialsId") final String towerCredentialsId,
                 @QueryParameter("towerTrustCert") final boolean towerTrustCert,
                 @QueryParameter("enableDebugging") final boolean enableDebugging
@@ -136,7 +148,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
             // Also, validate that we are an Administrator
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
             TowerLogger.writeMessage("Starting to test connection with (" + towerURL + ") and (" + towerCredentialsId + ") and (" + towerTrustCert + ") with debugging (" + enableDebugging + ")");
-            TowerConnector testConnector = TowerInstallation.getTowerConnectorStatic(towerURL, towerCredentialsId, towerTrustCert, enableDebugging, null);
+            TowerConnector testConnector = TowerInstallation.getTowerConnectorStatic(towerURL, towerCredentialsId, towerTrustCert, enableDebugging, null, towerApiBasePath);
             try {
                 testConnector.testConnection();
                 return FormValidation.ok("Success");
@@ -159,11 +171,17 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
             );
         }
 
+        public ListBoxModel doFillTowerApiBasePathItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("Tower/AWX Legacy (/api/v2)", TowerConnector.API_BASE_PATH_LEGACY);
+            items.add("AAP 2.5+ Controller (/api/controller/v2)", TowerConnector.API_BASE_PATH_AAP_CONTROLLER);
+            return items;
+        }
+
         @Override
         public String getDisplayName() {
             return "Tower Installation";
         }
     }
 }
-
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
@@ -55,6 +55,10 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
         this.enableDebugging = enableDebugging;
     }
 
+    public TowerInstallation(String towerDisplayName, String towerURL, String towerCredentialsId, boolean towerTrustCert, boolean enableDebugging) {
+        this(towerDisplayName, towerURL, null, TowerConnector.API_BASE_PATH_LEGACY, towerCredentialsId, towerTrustCert, enableDebugging);
+    }
+
     public String getTowerDisplayName() {
         return this.towerDisplayName;
     }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
@@ -37,6 +37,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     private final String towerDisplayName;
     private final String towerURL;
+    private String towerDisplayURL;
     private String towerApiBasePath;
     private String towerCredentialsId;
     private final boolean towerTrustCert;
@@ -44,10 +45,11 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
     private Run run;
 
     @DataBoundConstructor
-    public TowerInstallation(String towerDisplayName, String towerURL, String towerApiBasePath, String towerCredentialsId, boolean towerTrustCert, boolean enableDebugging) {
+    public TowerInstallation(String towerDisplayName, String towerURL, String towerDisplayURL, String towerApiBasePath, String towerCredentialsId, boolean towerTrustCert, boolean enableDebugging) {
         this.towerDisplayName = towerDisplayName;
         this.towerCredentialsId = towerCredentialsId;
         this.towerURL = towerURL;
+        this.towerDisplayURL = TowerConnector.normalizeBaseURL(towerDisplayURL);
         this.towerApiBasePath = TowerConnector.normalizeApiBasePath(towerApiBasePath);
         this.towerTrustCert = towerTrustCert;
         this.enableDebugging = enableDebugging;
@@ -59,6 +61,10 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     public String getTowerURL() {
         return this.towerURL;
+    }
+
+    public String getTowerDisplayURL() {
+        return this.towerDisplayURL;
     }
 
     public String getTowerApiBasePath() {
@@ -87,7 +93,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     public TowerConnector getTowerConnector() {
         return TowerInstallation.getTowerConnectorStatic(this.towerURL, this.towerCredentialsId, this.towerTrustCert,
-                this.enableDebugging, this.run, this.getTowerApiBasePath());
+                this.enableDebugging, this.run, this.getTowerApiBasePath(), this.getTowerDisplayURL());
     }
 
     public static TowerConnector getTowerConnectorStatic(String towerURL, String towerCredentialsId, boolean trustCert,
@@ -97,6 +103,11 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
 
     public static TowerConnector getTowerConnectorStatic(String towerURL, String towerCredentialsId, boolean trustCert,
                                                          boolean enableDebugging, Run run, String towerApiBasePath) {
+        return getTowerConnectorStatic(towerURL, towerCredentialsId, trustCert, enableDebugging, run, towerApiBasePath, null);
+    }
+
+    public static TowerConnector getTowerConnectorStatic(String towerURL, String towerCredentialsId, boolean trustCert,
+                                                         boolean enableDebugging, Run run, String towerApiBasePath, String towerDisplayURL) {
         String username = null;
         String password = null;
         String oauth_token = null;
@@ -115,7 +126,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
                 }
             }
         }
-        TowerConnector testConnector = new TowerConnector(towerURL, username, password, oauth_token, trustCert, enableDebugging, towerApiBasePath);
+        TowerConnector testConnector = new TowerConnector(towerURL, username, password, oauth_token, trustCert, enableDebugging, towerApiBasePath, towerDisplayURL);
         return testConnector;
     }
     
@@ -184,4 +195,3 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
         }
     }
 }
-

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProjectSync.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProjectSync.java
@@ -114,7 +114,7 @@ public class TowerProjectSync implements Serializable {
     }
 
     public String getURL() {
-        return connection.getURL() +"/#/jobs/project/"+ syncData.getLong("id");
+        return connection.getProjectSyncURL(syncData.getLong("id"));
     }
 
     public long getID() {

--- a/src/main/resources/org/jenkinsci/plugins/ansible_tower/AnsibleTowerGlobalConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible_tower/AnsibleTowerGlobalConfig/config.jelly
@@ -10,6 +10,9 @@
                     <f:entry title="${%URL}" field="towerURL" help="/plugin/ansible-tower/help-url.html">
                         <f:textbox/>
                     </f:entry>
+                    <f:entry title="${%Display URL}" field="towerDisplayURL" help="/plugin/ansible-tower/help-display-url.html">
+                        <f:textbox/>
+                    </f:entry>
                     <f:entry title="${%API Base Path}" field="towerApiBasePath" help="/plugin/ansible-tower/help-api-base-path.html">
                         <f:select/>
                     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ansible_tower/AnsibleTowerGlobalConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ansible_tower/AnsibleTowerGlobalConfig/config.jelly
@@ -10,6 +10,9 @@
                     <f:entry title="${%URL}" field="towerURL" help="/plugin/ansible-tower/help-url.html">
                         <f:textbox/>
                     </f:entry>
+                    <f:entry title="${%API Base Path}" field="towerApiBasePath" help="/plugin/ansible-tower/help-api-base-path.html">
+                        <f:select/>
+                    </f:entry>
                     <f:entry title="${%Credentials}" field="towerCredentialsId">
                         <c:select/>
                     </f:entry>
@@ -22,7 +25,7 @@
 
                     <f:validateButton
                             title="${%Test Connection}" progress="${%Testing...}"
-                            method="testTowerConnection" with="towerURL,towerCredentialsId,towerTrustCert,enableDebugging" />
+                            method="testTowerConnection" with="towerURL,towerApiBasePath,towerCredentialsId,towerTrustCert,enableDebugging" />
 
                     <f:entry>
                         <div align="right">

--- a/src/main/webapp/help-api-base-path.html
+++ b/src/main/webapp/help-api-base-path.html
@@ -1,0 +1,5 @@
+<div>
+    Select the controller API base path used by this installation.
+    Existing Tower and AWX installations should use the legacy <code>/api/v2</code> path.
+    Newer AAP controller deployments can use <code>/api/controller/v2</code>.
+</div>

--- a/src/main/webapp/help-display-url.html
+++ b/src/main/webapp/help-display-url.html
@@ -1,0 +1,5 @@
+<div>
+    Optional base URL used only when Jenkins prints links to the Tower, AWX, or AAP Controller UI.
+    Leave this blank to use the configured API URL for UI links. Set it when the API/gateway URL
+    and the controller UI URL are different.
+</div>

--- a/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -63,6 +63,20 @@ public class TowerConnectorTest {
     }
 
     @Test
+    public void shouldProbeOAuthSupport_keepsLegacyProbe() {
+        Assert.assertThat(
+                TowerConnector.shouldProbeOAuthSupport(TowerConnector.API_BASE_PATH_LEGACY),
+                CoreMatchers.is(true));
+    }
+
+    @Test
+    public void shouldProbeOAuthSupport_skipsProbeForAAPControllerMode() {
+        Assert.assertThat(
+                TowerConnector.shouldProbeOAuthSupport(TowerConnector.API_BASE_PATH_AAP_CONTROLLER),
+                CoreMatchers.is(false));
+    }
+
+    @Test
     public void selectUIBaseURL_usesApiURLWhenDisplayURLIsBlank() {
         Assert.assertThat(
                 TowerConnector.selectUIBaseURL("https://gateway.example.com/", ""),

--- a/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -61,4 +61,18 @@ public class TowerConnectorTest {
                 TowerConnector.buildOAuthTokenEndpoint(TowerConnector.API_BASE_PATH_AAP_CONTROLLER),
                 CoreMatchers.is(TowerConnector.API_GATEWAY_TOKEN_ENDPOINT));
     }
+
+    @Test
+    public void selectUIBaseURL_usesApiURLWhenDisplayURLIsBlank() {
+        Assert.assertThat(
+                TowerConnector.selectUIBaseURL("https://gateway.example.com/", ""),
+                CoreMatchers.is("https://gateway.example.com"));
+    }
+
+    @Test
+    public void selectUIBaseURL_prefersDisplayURL() {
+        Assert.assertThat(
+                TowerConnector.selectUIBaseURL("https://gateway.example.com", "https://controller.example.com/"),
+                CoreMatchers.is("https://controller.example.com"));
+    }
 }

--- a/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.ansible_tower.util;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TowerConnectorTest {
+
+    @Test
+    public void normalizeBaseURL_removesTrailingSlash() {
+        Assert.assertThat(
+                TowerConnector.normalizeBaseURL("https://tower.example.com/"),
+                CoreMatchers.is("https://tower.example.com"));
+    }
+
+    @Test
+    public void normalizeApiBasePath_defaultsToLegacy() {
+        Assert.assertThat(
+                TowerConnector.normalizeApiBasePath(null),
+                CoreMatchers.is(TowerConnector.API_BASE_PATH_LEGACY));
+    }
+
+    @Test
+    public void normalizeApiBasePath_addsLeadingSlashAndRemovesTrailingSlash() {
+        Assert.assertThat(
+                TowerConnector.normalizeApiBasePath("api/controller/v2/"),
+                CoreMatchers.is(TowerConnector.API_BASE_PATH_AAP_CONTROLLER));
+    }
+
+    @Test
+    public void buildEndpoint_usesLegacyApiBasePathByDefault() {
+        Assert.assertThat(
+                TowerConnector.buildEndpoint("jobs/", null),
+                CoreMatchers.is("/api/v2/jobs/"));
+    }
+
+    @Test
+    public void buildEndpoint_usesAAPControllerApiBasePath() {
+        Assert.assertThat(
+                TowerConnector.buildEndpoint("jobs/", TowerConnector.API_BASE_PATH_AAP_CONTROLLER),
+                CoreMatchers.is("/api/controller/v2/jobs/"));
+    }
+
+    @Test
+    public void buildEndpoint_keepsAbsoluteApiEndpoint() {
+        Assert.assertThat(
+                TowerConnector.buildEndpoint("/api/v2/jobs/", TowerConnector.API_BASE_PATH_AAP_CONTROLLER),
+                CoreMatchers.is("/api/v2/jobs/"));
+    }
+}

--- a/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -47,4 +47,18 @@ public class TowerConnectorTest {
                 TowerConnector.buildEndpoint("/api/v2/jobs/", TowerConnector.API_BASE_PATH_AAP_CONTROLLER),
                 CoreMatchers.is("/api/v2/jobs/"));
     }
+
+    @Test
+    public void buildOAuthTokenEndpoint_usesLegacyApiBasePathByDefault() {
+        Assert.assertThat(
+                TowerConnector.buildOAuthTokenEndpoint(null),
+                CoreMatchers.is("/api/v2/tokens/"));
+    }
+
+    @Test
+    public void buildOAuthTokenEndpoint_usesGatewayForAAPControllerApiBasePath() {
+        Assert.assertThat(
+                TowerConnector.buildOAuthTokenEndpoint(TowerConnector.API_BASE_PATH_AAP_CONTROLLER),
+                CoreMatchers.is(TowerConnector.API_GATEWAY_TOKEN_ENDPOINT));
+    }
 }

--- a/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/test/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -75,4 +75,46 @@ public class TowerConnectorTest {
                 TowerConnector.selectUIBaseURL("https://gateway.example.com", "https://controller.example.com/"),
                 CoreMatchers.is("https://controller.example.com"));
     }
+
+    @Test
+    public void buildJobURL_keepsLegacyJobURL() {
+        Assert.assertThat(
+                TowerConnector.buildJobURL("https://tower.example.com", TowerConnector.API_BASE_PATH_LEGACY, 123, TowerConnector.JOB_TEMPLATE_TYPE),
+                CoreMatchers.is("https://tower.example.com/#/jobs/123"));
+    }
+
+    @Test
+    public void buildJobURL_keepsLegacyWorkflowURL() {
+        Assert.assertThat(
+                TowerConnector.buildJobURL("https://tower.example.com", TowerConnector.API_BASE_PATH_LEGACY, 456, TowerConnector.WORKFLOW_TEMPLATE_TYPE),
+                CoreMatchers.is("https://tower.example.com/#/workflows/456"));
+    }
+
+    @Test
+    public void buildJobURL_usesAAPControllerPlaybookOutputURL() {
+        Assert.assertThat(
+                TowerConnector.buildJobURL("https://controller.example.com", TowerConnector.API_BASE_PATH_AAP_CONTROLLER, 123, TowerConnector.JOB_TEMPLATE_TYPE),
+                CoreMatchers.is("https://controller.example.com/execution/jobs/playbook/123/output"));
+    }
+
+    @Test
+    public void buildJobURL_usesAAPControllerWorkflowOutputURL() {
+        Assert.assertThat(
+                TowerConnector.buildJobURL("https://controller.example.com", TowerConnector.API_BASE_PATH_AAP_CONTROLLER, 456, TowerConnector.WORKFLOW_TEMPLATE_TYPE),
+                CoreMatchers.is("https://controller.example.com/execution/jobs/workflow/456/output"));
+    }
+
+    @Test
+    public void buildProjectSyncURL_keepsLegacyProjectSyncURL() {
+        Assert.assertThat(
+                TowerConnector.buildProjectSyncURL("https://tower.example.com", TowerConnector.API_BASE_PATH_LEGACY, 789),
+                CoreMatchers.is("https://tower.example.com/#/jobs/project/789"));
+    }
+
+    @Test
+    public void buildProjectSyncURL_usesAAPControllerProjectUpdateOutputURL() {
+        Assert.assertThat(
+                TowerConnector.buildProjectSyncURL("https://controller.example.com", TowerConnector.API_BASE_PATH_AAP_CONTROLLER, 789),
+                CoreMatchers.is("https://controller.example.com/execution/jobs/project_update/789/output"));
+    }
 }


### PR DESCRIPTION
### Submitter checklist
- [ ] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

## Description

This change updates `TowerConnector` and related configuration to support AAP controller and gateway API routing while preserving legacy Tower/AWX behavior.

## What changed

- detect controller API base between `/api/controller/v2` and `/api/v2`
- normalize configured base URLs before building API requests
- add optional Display URL support for controller UI links
- prefer gateway token endpoint `/api/gateway/v1/tokens/` in AAP controller mode
- retain legacy OAuth probe behavior for Tower/AWX mode
- retain legacy `authtoken` and basic auth fallback behavior
- delete OAuth tokens using the same API family that created them
- generate AAP Controller execution output links for playbook, workflow, and project update jobs
- preserve the existing `TowerInstallation` constructor overload for compatibility
- document AAP 2.5+ controller compatibility mode

## Why

AAP 2.5+ moved controller resources behind `/api/controller/v2` and shifted token handling toward gateway APIs. The plugin previously assumed legacy `/api/v2` endpoints and legacy UI links, which can break connectivity or produce incorrect job output links against newer AAP platform versions.

This change keeps existing plugin ID and Pipeline steps unchanged, including `ansibleTower`, `ansibleTowerProjectSync`, and `ansibleTowerProjectRevision`.

## Issues / References

Jira: https://issues.jenkins.io/browse/JENKINS-75426

## Related pull requests

No related pull requests yet.

## Testing

Validated locally with:

```bash
mvn clean install