### PR TITLE
update pom.xml metadata for 0.18.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>ansible-tower</artifactId>
-    <version>0.17.1-SNAPSHOT</version>
+    <version>0.18.0</version>
     <packaging>hpi</packaging>
     <name>Ansible Tower Plugin</name>
     <description>
@@ -36,7 +36,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ansible-tower-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ansible-tower-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ansible-tower-plugin</url>
-        <tag>ansible-tower-0.17.0</tag>
+        <tag>ansible-tower-0.18.0</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
Is the release tagged in Github missing the updated release metadata in the `pom.xml` for the release to show up in the plugin catalog?

### Testing done

no testing done. There was no code change, only the release info was updated in the metadata

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
