### PR TITLE
fix: Retry transient gateway errors when polling workflow events

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -51,8 +51,8 @@ public class TowerConnector implements Serializable {
     public static final String API_BASE_PATH_AAP_CONTROLLER = "/api/controller/v2";
     public static final String API_GATEWAY_TOKEN_ENDPOINT = "/api/gateway/v1/tokens/";
     private static final String ARTIFACTS = "artifacts";
-    private static final int MAX_JOB_STATUS_RETRIES = 5;
-    private static final long JOB_STATUS_RETRY_DELAY_MS = 10000L;
+    private static final int MAX_TRANSIENT_GATEWAY_RETRIES = 5;
+    private static final long TRANSIENT_GATEWAY_RETRY_DELAY_MS = 10000L;
 
     private String authorizationHeader = null;
     private String oauthToken = null;
@@ -771,18 +771,18 @@ public class TowerConnector implements Serializable {
 
         int retryCount = 0;
         while(isTransientGatewayStatus(response.getStatusLine().getStatusCode())
-                && retryCount < MAX_JOB_STATUS_RETRIES) {
+                && retryCount < MAX_TRANSIENT_GATEWAY_RETRIES) {
             retryCount++;
             int statusCode = response.getStatusLine().getStatusCode();
             logger.logMessage("Job status poll failed: jobID=" + jobID
                 + ", templateType=" + templateType
                 + ", endpoint=" + buildEndpoint(apiEndpoint)
                 + ", httpStatus=" + statusCode
-                + ", retry=" + retryCount + "/" + MAX_JOB_STATUS_RETRIES
-                + ", retryDelaySeconds=" + (JOB_STATUS_RETRY_DELAY_MS / 1000L));
+                + ", retry=" + retryCount + "/" + MAX_TRANSIENT_GATEWAY_RETRIES
+                + ", retryDelaySeconds=" + (TRANSIENT_GATEWAY_RETRY_DELAY_MS / 1000L));
             EntityUtils.consumeQuietly(response.getEntity());
             try {
-                Thread.sleep(JOB_STATUS_RETRY_DELAY_MS);
+                Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
             } catch(InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 throw new AnsibleTowerException("Interrupted while retrying job status request after HTTP "
@@ -927,7 +927,29 @@ public class TowerConnector implements Serializable {
     private Vector<String> logWorkflowEvents(long jobID, boolean importWorkflowChildLogs) throws AnsibleTowerException {
         Vector<String> events = new Vector<String>();
         if(!this.logIdForWorkflows.containsKey(jobID)) { this.logIdForWorkflows.put(jobID, 0L); }
-        HttpResponse response = makeRequest(GET, "/workflow_jobs/"+ jobID +"/workflow_nodes/?id__gt="+this.logIdForWorkflows.get(jobID));
+        String apiEndpoint = "/workflow_jobs/"+ jobID +"/workflow_nodes/?id__gt="+this.logIdForWorkflows.get(jobID);
+        HttpResponse response = makeRequest(GET, apiEndpoint);
+
+        int retryCount = 0;
+        while(isTransientGatewayStatus(response.getStatusLine().getStatusCode())
+                && retryCount < MAX_TRANSIENT_GATEWAY_RETRIES) {
+            retryCount++;
+            int statusCode = response.getStatusLine().getStatusCode();
+            logger.logMessage("Workflow events poll failed: jobID=" + jobID
+                + ", endpoint=" + buildEndpoint(apiEndpoint)
+                + ", httpStatus=" + statusCode
+                + ", retry=" + retryCount + "/" + MAX_TRANSIENT_GATEWAY_RETRIES
+                + ", retryDelaySeconds=" + (TRANSIENT_GATEWAY_RETRY_DELAY_MS / 1000L));
+            EntityUtils.consumeQuietly(response.getEntity());
+            try {
+                Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
+            } catch(InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new AnsibleTowerException("Interrupted while retrying workflow events request after HTTP "
+                    + statusCode + " for job " + jobID);
+            }
+            response = makeRequest(GET, apiEndpoint);
+        }
 
         if(response.getStatusLine().getStatusCode() == 200) {
             JSONObject responseObject;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

  This change adds retry handling for transient HTTP gateway errors when polling workflow events.
<img width="1054" height="230" alt="image" src="https://github.com/user-attachments/assets/5d8bce2b-6086-4fe8-bbd9-00de9c01cdf6" />

  The plugin now retries requests to the workflow nodes endpoint when AAP returns HTTP 502, 503, or 504:

  - Retries up to 5 times.
  - Waits 10 seconds between attempts.
  - Consumes failed responses before retrying.
  - Logs the endpoint, HTTP status, retry count, and delay.
  - Preserves the thread interruption status if the retry wait is interrupted.

  The existing job status polling retry constants are also renamed so they can be shared with workflow event polling.

  ### Testing done

  - Executed the automated test suite with:

    ```shell
    mvn -q -DskipTests=false test

  - All tests passed successfully.
  - Executed git diff --check; no whitespace errors were found.
  - Verified that HTTP 502, 503, and 504 are classified as transient gateway errors.
  - Verified that non-transient responses still follow the existing error-handling behavior.

  ### Submitter checklist

  - [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [ ] Link to relevant issues in GitHub or Jira
  - [ ] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
  <!--
  Put an `x` into the [ ] to show you have filled the information.
  The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
  You can override it by creating .github/pull_request_template.md in your own repository.
  -->