### PR TITLE
Improve plugin logging and make workflow polling resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,511 +1,357 @@
-Ansible Tower Plugin
-====================
+# Ansible Tower Plugin
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/ansible-tower.svg)](https://plugins.jenkins.io/ansible-tower)
-[![GitHub release](https://img.shields.io/github/release/jenkinsci/ansible-tower-plugin.svg?label=changelog)](https://github.com/jenkinsci/ansible-tower-plugin/releases/latest)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/ansible-tower.svg?color=blue)](https://plugins.jenkins.io/ansible-tower)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/ansible-tower-plugin.svg?label=changelog)](https://github.com/jenkinsci/ansible-tower-plugin/releases/latest)
 
-## About this plugin
+The Ansible Tower Plugin connects Jenkins to Ansible Tower, AWX, and Red Hat Ansible Automation Platform (AAP). It supports Freestyle projects and Pipeline jobs that need to:
 
-This plugin connects Jenkins to [Ansible Tower](http://www.ansible.com/) to do the following things:
-* Run jobs as a build step
-* Update projects
+- Launch job templates and workflow job templates.
+- Wait for jobs and import controller output.
+- Run project syncs.
+- Change a project's SCM revision.
+- Pass Jenkins environment variables to launch parameters.
+- Return job metadata and exported Ansible values to Jenkins.
 
 ## Requirements
 
-* Jenkins 2.479.1 or newer
-* Java 21 or newer to run Jenkins and this plugin
-* JDK 21 and Maven 3.9.6 or newer to build the plugin locally
+- Jenkins 2.479.1 or newer.
+- Java 21 or newer.
+- A reachable Tower, AWX, or AAP controller API.
+- A Jenkins credential with sufficient controller permissions.
 
-## Configuration
+For local development, use JDK 21 and Maven 3.9.6 or newer.
 
-After installing the plugin you can configure Ansible Tower servers in the Jenkins Global Configuration under the section *Ansible Tower* by clicking the add button.
+## Installation
 
-![Configure Plugin](./docs/images/configuration-0.7.0.png)
+Install **Ansible Tower** from **Manage Jenkins → Plugins**, or upload a locally built `ansible-tower.hpi` from the plugin manager's advanced settings.
 
-The fields are as follows:
+After installation, configure at least one controller under **Manage Jenkins → System → Ansible Tower**.
 
-| Field Name  | Description |
-|-------------|----------------|
-| Credentials | The credentials within Jenkins to be used to connect to the Ansible Tower server.<br/>* For basic auth use a "Username with password" type credential<br/>* For oAuth (starting in Tower 3.3.0) use a "Secret Text" type credential from the [Plain Credentials Plugin](https://plugins.jenkins.io/plain-credentials)<br/>See the OAuth Authentication section of this document for more details on setting up oAuth.|
-| Enable Debugging | This will allow the plugin to write detailed messages into the jenkins.log for debugging purposes. It will show show requests to the server and payloads. This can contain a lot of data. All messages are prefixed with \[Ansible-Tower].<br/><br/>For Example:<br/><br/>[Ansible-Tower] building request to https://192.168.56.101/api/v1/workflow_jobs/200/workflow_nodes/<br/>[Ansible-Tower] Adding auth for admin<br/>[Ansible-Tower] Forcing cert trust</br> [Ansible-Tower] {"count":4,"next":null ...</br>|
-| Force Trust Cert | If your Ansible Tower instance is using an https cert that Jenkins does not trust, and you want the plugin to trust the cert anyway, you can click this box.<br/><br/>You should really understand the implications if you are going to use this option. Its meant for testing purposes only. |
-| Name | The name that this Ansible Tower installation will be referenced as. |
-| URL | The base URL used for API calls to the Ansible Tower, AWX, or AAP gateway/controller.|
-| API Base Path | API path used for controller API calls. Use `/api/v2` for Tower/AWX legacy installations. Use `/api/controller/v2` for AAP 2.5+ controller deployments.|
+## Global configuration
 
-Once the settings are completed, you can test the connection between Jenkins and Ansible Tower by clicking on the Test Connection button.
+Each configured installation has the following fields:
 
-## AAP 2.5+ Compatibility
+| Field | Description |
+| --- | --- |
+| Name | Name used by Freestyle builds and the Pipeline `towerServer` parameter. |
+| URL | Controller or AAP gateway base URL, without an API path; for example `https://aap.example.com`. |
+| API Base Path | Use `/api/v2` for Tower/AWX or `/api/controller/v2` for AAP 2.5+ controller APIs. |
+| Credentials | Default Jenkins credential for this installation. Pipeline and Freestyle steps can override it. |
+| Force Trust Cert | Disables normal TLS certificate validation. Use only for controlled test environments. |
+| Enable Debugging | Allows detailed `FINE` diagnostics. A Jenkins Log Recorder must also enable `FINE` or `ALL`. |
 
-Existing Pipeline steps and Freestyle build steps remain unchanged. Jobs that already use `ansibleTower`, `ansibleTowerProjectSync`, or `ansibleTowerProjectRevision` do not need to be renamed.
+Use **Test Connection** to verify the URL, API path, TLS setting, and credential.
 
-For AAP 2.5+ controller deployments, configure the installation like this:
+### AAP 2.5+
+
+Configure an AAP gateway/controller installation as follows:
 
 ```text
 URL: https://aap-gateway.example.com
 API Base Path: /api/controller/v2
 ```
 
-In this mode, controller API calls use `/api/controller/v2/...`, while Jenkins-created OAuth tokens use the gateway token endpoint `/api/gateway/v1/tokens/`.
-Generated job links are selected from the configured API Base Path and the job type returned by the controller API. Legacy Tower/AWX workflow jobs use `/#/jobs/workflow/<id>`, while AAP controller workflow jobs use `/execution/jobs/workflow/<id>/output`.
+Controller calls then use `/api/controller/v2/...`. OAuth tokens created from username/password credentials use the AAP gateway endpoint `/api/gateway/v1/tokens/`.
 
-## Basic Authentication
+The configured API path also controls generated UI links:
 
-This plugin can use a username password to attempt to authenticate with Tower. As of plugin version 0.13.0 when using username/password the plugin will attempt to:
-  * Pull an OAuth2 token
-  * Attempt to use a pre-oauth authtoken
-  * Fall back to basic auth
+- Tower/AWX workflow: `/#/jobs/workflow/<id>`
+- AAP workflow: `/execution/jobs/workflow/<id>/output`
+- AAP job: `/execution/jobs/playbook/<id>/output`
 
-If you are using plugin version >= 0.13.0 with Basic Auth and pipelines leveraging the async method please see the note at the bottom of section `Async Execution` for details about freeing Tower tokens.
+## Authentication
 
-## OAuth Authentication
+The plugin accepts these Jenkins credential types:
 
-Starting in Tower version 3.3.0, Oauth Authentication can be used alongside basic auth. Beginning in Tower version 3.4.0, **basic authentication will be disabled**.
+### Username with password
 
-The [Ansible Tower Documentation](https://docs.ansible.com/ansible-tower/latest/html/userguide/applications_auth.html)
- covers this in detail, but here is a rough outline of what needs to be performed.
+When a username/password credential is selected, the plugin attempts authentication in this order:
 
-Tower Configuration
+1. Create an OAuth token.
+2. Try the legacy authtoken endpoint when supported.
+3. Fall back to HTTP Basic authentication.
 
-1. Add an Application for the Jenkins Oauth tokens
-   * Name (i.e. "Jenkins")
-   * Description (optional)
-   * Organization (The organization which covers the JTs and WFJTs you will be using)
-   * Authorization Grant Type = Resource owner password-based
-   * Client Type = Confidential
-1. Add or create a user to bind to an Oauth token
-   * This should be a service account with limited permissions.
-   * Add a Token for this user with the Users / <Username> / Tokens / Create Token dialogue (with the appropriate scope)
-   * Copy the Token ID which is generated on the prompt.
+The account should be a dedicated service account with only the permissions required to read and launch the configured resources.
 
-Jenkins Configuration
+### Secret text bearer token
 
-1. Install this plugin (it must be a version >= 0.90)
-1. Add a Credential
-   * Choose the appropriate scope
-   * Secret = Token ID from step 2.c above
-   * ID = Something to denote it's purpose (i.e. "jenkins-tower-token")
-   * Description (optional)
-1. Complete the configuration steps as defined in this guide's 'Configuration'
+Store the actual OAuth access token value in a Jenkins **Secret text** credential. The plugin sends it as a bearer token and does not create or delete that externally managed token.
 
-## Job Execution
+Secret text credentials require the [Plain Credentials Plugin](https://plugins.jenkins.io/plain-credentials/).
 
-### Adding a Build Step
+Do not enter a token database ID or token record ID; Jenkins needs the access token value.
 
-In a freestyle project a new build step called Ansible Tower is now available:
+## Run a job or workflow template
 
-![Run Job Build Step](./docs/images/run_job_freestyle.png)
+Freestyle projects provide an **Ansible Tower** build step. Pipeline jobs use `ansibleTower`.
 
-| Field | Description |
-|-------|-------------|
-| Tower Server | The predefined Ansible Tower server to run the template on.|
-| Tower Credentials Override | Overrides the credentials from global Ansible Tower configuration.|
-| Template Type | Whether you are running a job or workflow template.|
-| Template ID | The name or numerical ID of the template to be run on the Ansible Tower server.|
-| Extra Vars | Additional variables to be passed to the job. I.e.:<br/>---<br/>my_var: This is a variable called my_var|
-| Job Tags | Any job tags to be passed to Ansible Tower.|
-| Skip Job Tags | Any skip tags to be passed to Ansible Tower.|
-| Job Type | Is this a template run or a check.|
-| Limit | The servers to limit the invocation to.|
-| Inventory | The name or numeric ID of the inventory to run the job on.|
-| Credential | The name or numeric ID of the credentials to run the job with.|
-| SCM Branch | The name of the SCM branch to overide while running te job.|
-| Verbose | Add additional messages to the Jenkins console about the job run.|
-| Import Tower Output | Pull the logs from Ansible Tower into the Jenkins console. Options include:<br/><ul><li><b>Do not import</b> Do not import the Ansible Tower logs into Jenkins (old checkbox not checked)</li><li><b>Import Truncated Logs</b> Pull in logs as they appear in Ansible Tower UI (long lines are truncated with ....) (old checkbox checked)</li><li><b>Import Full Logs</b> This will pull non-truncated events from Ansible Tower.</li><li><b>Process Variables Only</b> Consume the logs from Tower to process for variables but do not log in the Jenkins log.</li></ol>|
-| Import Workflow Child Output | Pull in the output from all of the jobs that the template runs.|
-| Remove Color | When importing the Ansible Tower output, strip off the ansi color encodings.|
-
-### Pipeline support
-Tower jobs can be executed from workflow scripts.
-The towerServer and jobTemplate are the only required parameters.
+The minimum Pipeline configuration is `towerServer`, `towerCredentialsId`, `jobTemplate`, and `jobType`. `towerCredentialsId` may be an empty string to use the globally configured credential.
 
 ```groovy
-node {
-    stage('MyStage') {
-        ansibleTower(
-            towerServer: 'Prod Tower',
-            towerCredentialsId: '',
-            templateType: 'job',
-            jobTemplate: 'Simple Test',
-            towerLogLevel: 'full',
-            inventory: 'Demo Inventory',
-            jobTags: '',
-            skipJobTags: '',
-            limit: '',
-            removeColor: false,
-            verbose: true,
-            credential: '',
-            extraVars: '''---
-my_var:  "Jenkins Test"''',
-            async: false
-        )
-    }
-}
+def result = ansibleTower(
+    towerServer: 'AAP UAT',
+    towerCredentialsId: '',
+    jobTemplate: 'Deploy application',
+    jobType: 'run',
+    templateType: 'job',
+    towerLogLevel: 'full',
+    extraVars: '''---
+environment: uat
+release: "${BUILD_TAG}"
+''',
+    inventory: 'UAT Inventory',
+    removeColor: true,
+    throwExceptionWhenFail: true,
+    async: false
+)
+
+echo "AAP job ${result.JOB_ID}: ${result.JOB_URL}"
+echo "Result: ${result.JOB_RESULT}"
 ```
 
-## Project Update
+### Parameters
 
-### Adding a Build Step
-In a freestyle project a new build called Ansible Tower Project Sync is now available:
+| Parameter | Values/default | Description |
+| --- | --- | --- |
+| `towerServer` | Required | Name of a globally configured installation. |
+| `towerCredentialsId` | Required; `''` uses global credential | Optional per-build credential override. |
+| `jobTemplate` | Required | Template name or numeric ID. |
+| `jobType` | `run` or `check`; default `run` | Job launch type. |
+| `templateType` | `job` or `workflow`; default `job` | Selects job template or workflow job template APIs. |
+| `extraVars` | Empty | YAML or JSON launch variables. |
+| `inventory` | Empty | Inventory name or numeric ID. |
+| `credential` | Empty | Controller credential name or numeric ID. Multiple credentials may be comma-separated where supported. |
+| `limit` | Empty | Host limit passed at launch. |
+| `jobTags` | Empty | Job tags passed at launch. |
+| `skipJobTags` | Empty | Tags to skip. |
+| `scmBranch` | Empty | SCM branch override. The template must allow prompting for SCM branch. |
+| `towerLogLevel` | `false` | Output import mode described below. |
+| `importWorkflowChildLogs` | `false` | Imports child job output for workflows. |
+| `removeColor` | `false` | Removes ANSI color sequences from imported output. |
+| `verbose` | `false` | Adds progress messages, including some expanded launch values, to the Jenkins build console. Avoid placing secrets in launch parameters when this is enabled. |
+| `throwExceptionWhenFail` | `true` | Fails the Pipeline step when the controller operation fails. |
+| `async` | `false` | Returns immediately with a job handle. |
 
-![Project Sync Build Step](./docs/images/project_sync_freestyle.png)
+The controller template must permit prompting for any launch-time overrides you provide, such as inventory, credential, variables, tags, limit, job type, or SCM branch.
 
-| Field | Description |
-|-------|-------------|
-| Tower Server | The predefined Ansible Tower server to run the sync on. |
-| Tower Credentials Override | Overrides the credentials from global Ansible Tower configuration. |
-| Project Name | The name of the project to perform the SCM sync. |
-| Verbose | Add additional messages to the Jenkins console about the job run.|
-| Import Tower Output | Pull all of the logs from Ansible Tower into the Jenkins console.|
-| Remove Color | When importing the Ansible Tower output, strip off the ansi color encodings.|
+### Output import modes
 
-### Pipeline Support
-Project syncs can be executed from workflow scripts. The ansibleTowerProjectSync function is made available through this plugin. The towerServer and project parameters are the only ones required.
-```groovy
-        projectSyncResults = ansibleTowerProjectSync(
-            async: true,
-            importTowerLogs: true,
-            project: 'Demo Project',
-            removeColor: false,
-            throwExceptionWhenFail: false,
-            towerServer: 'EC2 AWX 8',
-            verbose: false
-        )
-```
+| `towerLogLevel` | Behavior |
+| --- | --- |
+| `false` | Do not import controller output. |
+| `true` | Import the output exposed by the controller UI. Long lines may be truncated. |
+| `full` | Import full event output where available. |
+| `vars` | Process exported variables without printing controller output. |
 
-## Project Revision
+The legacy Boolean `importTowerLogs` option remains supported for compatibility, but new Pipeline code should use `towerLogLevel`.
 
-**Note:** You can run a project revision on a non-scm project. This will not raise an error to Jenkins as the Tower API will allow this to happen. 
+## Project operations
 
-**Note:** Tower will auto sync the project on the change of the revision. Therefore calling Ansible Tower Project Sync in a job after the update is redundant.
+### Project sync
 
-### Adding a Build Step
-In a freestyle project a new build called Ansible Tower Project Revision is now available:
-
-![Project Revision Build Step](,/docs/images/project_revision_freestyle.png)
-
-| Field | Description |
-|-------|-------------|
-| Tower Server | The predefined Ansible Tower server to run the sync on. |
-| Tower Credentials Override | Overrides the credentials from global Ansible Tower configuration. |
-| Project Name | The name of the project to perform the SCM sync. |
-| Revision | The revision to set for the specified project.|
-| Verbose | Add additional messages to the Jenkins console about the job run.|
-
-### Pipeline Support
-Project revision can be executed from workflow scripts. The ansibleTowerProjectRevision function is made available through this plugin. The towerServer, project and revision parameters are the only ones required.
-```groovy
-        projectSyncResults = ansibleTowerProjectRevision(
-            towerServer: 'EC2 AWX 8',
-            project: 'Demo Project',
-            revision: 'v1.0',
-            throwExceptionWhenFail: false,
-            verbose: false
-        )
-```
-
-## Async Execution
-
-As of version 0.10.0, pipeline scripts that run jobs within Tower support the async option. This will run the Tower task but immediately return the control of the job back to Jenkins. In the return value from either ansibleTower or ansibleTowerProjectSync will be an object that can be used later on to interact with the job:
+Freestyle projects provide **Ansible Tower Project Sync**. Pipeline jobs use `ansibleTowerProjectSync`:
 
 ```groovy
-stage('Launch Tower job') {
-    node('master') {
-        // Here we launching the Tower job in async mode
-        tower_job = ansibleTower(
-                async: true,
-                jobTemplate: 'Jenkins Export Vars',
-                templateType: 'job',
-                towerServer: 'Tower 3.6.0'
-        )
-        println("Tower job "+ tower_job.get("JOB_ID") +" was submitted. Job URL is: "+ tower_job.get("JOB_URL"))
-    }
-}
- 
-// Since control is returned this stage will run right away
-stage('Something else') {
-    node('master') {
-        println("Doing something else")
-    }
-}
- 
-// Now we can use our tower_job object to wait for the Tower job to complete
-stage('Wait for Tower job') {
-    node('master') {
-        def job = tower_job.get("job", null)
-        if(job == null) {
-            errir("The tower job was defined as null!")
-        }
-        timeout(120) {
-            waitUntil {
-                return job.isComplete()
-            }
-        }
-    }
-}
- 
-// Once the job is done we may want to do things like:
-//    * Get the logs
-//    * Check on exported values
-//    * See if the job was successful or not
-stage('Process Tower results') {
-    node('master') {
-        // Def a variable to save some typing
-        def job = tower_job.get("job", null)
-        if(job == null) {
-            error("Tower job was null")
-        }
- 
-        // First lets get and display the logs
-        def Vector<String> logs = job.getLogs()
-        for (String line : logs) {
-            println(line)
-        }
- 
-        // Now lets get our exports, these depend on us calling getLogs
-        def HashMap<String, String> exports = job.getExports()
-        def returned_value = exports.get("value", "Not Defined")
-        if(returned_value != "T-REX") {
-            println("Tower job did not return a T-Rex: "+ returned_value)
-        } else {
-            println("Exports were as expected")
-        }
- 
-        // Finally, lets see if the job was successful
-        boolean successful = job.wasSuccessful()
-        if(successful) {
-            println("Job ran successfully")
-        } else {
-            error("The job did not end well")
-        }
+def result = ansibleTowerProjectSync(
+    towerServer: 'AAP UAT',
+    towerCredentialsId: '',
+    project: 'Application Project',
+    importTowerLogs: true,
+    removeColor: true,
+    throwExceptionWhenFail: true,
+    async: false,
+    verbose: false
+)
 
-        // Release the Tower token (see note below)
-        job.releaseToken()
-    }
-}
+echo "Sync ${result.SYNC_ID}: ${result.SYNC_URL}"
+echo "Result: ${result.SYNC_RESULT}"
 ```
 
-**Note:** the above example would require in-process script approvals in order to be run. Specifically the following needed to be added:
+### Project revision
 
-* method java.util.Dictionary get java.lang.Object
-* method org.jenkinsci.plugins.ansible_tower.util.TowerJob getExports
-* method org.jenkinsci.plugins.ansible_tower.util.TowerJob getLogs
-* method org.jenkinsci.plugins.ansible_tower.util.TowerJob isComplete
-* method org.jenkinsci.plugins.ansible_tower.util.TowerJob wasSuccessful
-* method org.jenkinsci.plugins.ansible_tower.util.TowerJob releaseToken
-* new java.util.HashMap
-* new java.util.Vector
-
-Using ansibleTowerProjectSync will require similar script approvals:
-* method org.jenkinsci.plugins.ansible_tower.util.TowerProjectSync getLogs
-* method org.jenkinsci.plugins.ansible_tower.util.TowerProjectSync isComplete
-* method org.jenkinsci.plugins.ansible_tower.util.TowerProjectSync wasSuccessful
-* method org.jenkinsci.plugins.ansible_tower.util.TowerProjectSync releaseToken
-
-Please consider if you want these options added and use at your own risk.
-
-
-**Note:** with release 0.13 new auth procedures were implemented. If you are using a username/password credential a token will attempt to be retrieved when calling the Tower API. When running with the async option, the token will be released as soon as control is returned to your groovy script. If you many another call to the API (i.e. by calling getLogs) a new Token will be established. It is your responsibility to remove that token when you no longer need it. Failure to do so will leave dangling tokens in Tower.
-
-
-## Expanding Env Vars
-
-The fields passed to Tower (project, jobTemplate, extraVars, limit, jobTags, inventory, credential) can have Jenkins Env Vars placed inside of them and expanded. For example, if you had a job parameter as TAG you could expand that in the Extra Vars like this:
-```yaml
----
-my_var: "$TAG"
-```
-
-## Console Color
-
-You need to install another plugin like [AnsiColor plugin](https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin) to output a colorized Ansible log.
+Freestyle projects provide **Ansible Tower Project Revision**. Pipeline jobs use `ansibleTowerProjectRevision`:
 
 ```groovy
-node {
-    wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
-        ansibleTower(
-            towerServer: 'Prod Tower',
-            jobTemplate: 'Simple Test',
-            importTowerLogs: true,
-            inventory: 'Demo Inventory',
-            jobTags: '',
-            limit: '',
-            removeColor: false,
-            verbose: true,
-            credential: '',
-            extraVars: '''---
-            my_var: "Jenkins Test"'''
-        )
+ansibleTowerProjectRevision(
+    towerServer: 'AAP UAT',
+    towerCredentialsId: '',
+    project: 'Application Project',
+    revision: 'release/1.4',
+    throwExceptionWhenFail: true,
+    verbose: false
+)
+```
+
+Changing the revision may cause the controller to synchronize an SCM-backed project automatically. A manual project may accept the revision request without performing an SCM operation.
+
+## Asynchronous execution
+
+With `async: true`, a launch returns before the controller operation completes.
+
+An asynchronous `ansibleTower` result contains:
+
+- `JOB_ID`
+- `JOB_URL`
+- `job`, a `TowerJob` handle
+
+```groovy
+def submitted = ansibleTower(
+    towerServer: 'AAP UAT',
+    towerCredentialsId: '',
+    jobTemplate: 'Long deployment',
+    jobType: 'run',
+    templateType: 'workflow',
+    async: true
+)
+
+def job = submitted.get('job')
+try {
+    timeout(time: 30, unit: 'MINUTES') {
+        waitUntil {
+            job.isComplete()
+        }
     }
+
+    job.getLogs().each { line -> echo line }
+    if (!job.wasSuccessful()) {
+        error 'AAP workflow failed'
+    }
+} finally {
+    job.releaseToken()
 }
 ```
 
-If you do not have a plugin like AnsiColor or want to remove the color from the log set removeColor: true.
+`TowerJob` exposes `isComplete()`, `wasSuccessful()`, `getLogs()`, `getExports()`, `cancelJob()`, and `releaseToken()`.
 
+An asynchronous project sync result contains `SYNC_ID`, `SYNC_URL`, and a `sync` handle. `TowerProjectSync` exposes `isComplete()`, `wasSuccessful()`, `getLogs()`, `cancelSync()`, `getURL()`, `getID()`, and `releaseToken()`.
 
-## Returning Data
-The plugin supports sending data from Tower back to Jenkins for use in your job. For job runs, there are two methods for exporting data: Purpose Driven Logging and Setting Stats
+Jenkins may require Script Security approvals before untrusted Pipeline code can invoke methods on these returned Java objects.
 
-### Purpose Driven Logging
-Then, in your Tower job simply include a debugging statement like:
+When username/password authentication creates a temporary token, async mode releases the launch token before returning. Later handle calls may acquire another token; call `releaseToken()` when the handle is no longer needed.
+
+## Returned values
+
+Synchronous job results are returned as a `Properties`-like object containing:
+
+| Key | Availability | Description |
+| --- | --- | --- |
+| `JOB_ID` | Always after launch | Controller job ID. |
+| `JOB_URL` | Always after launch | Link to controller job output. |
+| `JOB_RESULT` | Synchronous execution | `SUCCESS` or `FAILED`. |
+| Exported keys | After export processing | Values produced through `JENKINS_EXPORT`. |
+
+Project sync results similarly contain `SYNC_ID`, `SYNC_URL`, and, for synchronous execution, `SYNC_RESULT`.
+
+### Export data from Ansible
+
+The plugin recognizes a purpose-driven output line:
 
 ```yaml
-    - name: Set a Jenkins variable
-      debug:
-        msg: "JENKINS_EXPORT VAR_NAME=value"
+- name: Export a value to Jenkins
+  ansible.builtin.debug:
+    msg: "JENKINS_EXPORT IMAGE_TAG=1.4.2"
 ```
- 
-The Tower plugin will recognize this message and use the EnvInject plugin to add an environment variable named VAR_NAME with a value of "value" into the pipeline for consumption by downstream tasks.
 
-### Setting Stats
-Another option is to use the set_stats module in Ansible like:
+It also recognizes controller artifacts created with `set_stats`:
 
 ```yaml
-    - name: Set a jenkins variable for with stat
-      set_stats:
-        data:
-          JENKINS_EXPORT:
-            - some_name: var_value
-            - some_other_var : Another value
-        aggregate: yes
-        per_host: no
+- name: Export structured values to Jenkins
+  ansible.builtin.set_stats:
+    data:
+      JENKINS_EXPORT:
+        - image_tag: "1.4.2"
+        - deployment_id: "deploy-42"
+    aggregate: true
+    per_host: false
 ```
 
-The Tower plugin will look for variables under JENKINS_EXPORT and use EnvInject plugin to add an environment variables into the pipeline for consumption by downstream tasks. In the previous example two variables would be created: some_name, set to var_value; and some_other_var set to "Another value".
+Pipeline jobs receive exported values in the returned result. Freestyle jobs can inject them through the optional [EnvInject Plugin](https://plugins.jenkins.io/envinject/). EnvInject has limited Pipeline compatibility, so Pipeline code should use the returned result instead of relying on `env`.
 
-**Please reference set_stats documentation for usage and additional parameters, per_host and aggregate are not necessarily needed.**
+## Jenkins environment variable expansion
 
-The process to leverage the returned data in Jenkins depends on your job type:
+The plugin expands Jenkins environment variables in these inputs before calling the controller:
 
-### Freestyle returns
-The plugin supports sending data back to Jenkins as environment variables via the [EnvInject plugin](https://wiki.jenkins.io/display/JENKINS/EnvInject+Plugin). First be sure the plugin is installed (its not a dependency for this plugin, it needs to be installed separately).
+- Job template
+- Extra variables
+- Limit
+- Job and skip tags
+- Inventory
+- Controller credential
+- SCM branch
+- Project and project revision
 
-If you try to export a variable but don't have the EnvInject plugin installed the Tower plugin will let you know with a message like:
+Example:
+
+```yaml
+release: "$BUILD_TAG"
+environment: "$DEPLOY_ENV"
+```
+
+## Console color
+
+Set `removeColor: true` to strip ANSI sequences. To preserve and render colors, install the [AnsiColor Plugin](https://plugins.jenkins.io/ansicolor/) and configure the Pipeline accordingly.
+
+## Logging and troubleshooting
+
+Plugin diagnostics use `java.util.logging` under this namespace:
 
 ```text
-    Found environment variables to inject but the EnvInject plugin was not found
+org.jenkinsci.plugins.ansible_tower
 ```
 
-* Important note: if you do use this plugin as a part of Jenkins Pipeline (under a script {} section) it is possible that you may not be able to access return values from Env variables. Only way to return and access values would be pipeline returns. Please see below. Reason:
-source: https://plugins.jenkins.io/envinject/
-```text
-Even though it is possible to set up the EnvInject Job Property and build step in Pipeline, the plugin does not provide full compatibility with Jenkins Pipeline.
+To collect detailed diagnostics:
 
-Supported use-cases:
+1. Select **Enable Debugging** on the global Tower installation.
+2. Open **Manage Jenkins → System Log**.
+3. Add a Log Recorder for `org.jenkinsci.plugins.ansible_tower` at `FINE` or `ALL`.
 
-    Injection of EnvVars defined in the "Properties Content" field of the Job Property
-        These EnvVars are being injected to the script environment and will be inaccessible via the "env" Pipeline global variable
-        Please note there is also a known compatibility issue with Durable Task Plugin 1.13
+Operational `WARNING` and `SEVERE` records are emitted even when debugging is disabled. Messages retain the `[Ansible-Tower]` prefix. System diagnostics do not log request/response payloads, credentials, authorization headers, or tokens. The separate `verbose` build-console option may print expanded launch values.
 
-All other use-cases of the plugin may work incorrectly in Jenkins Pipeline. Please see JENKINS-42614 for more information about unsupported use-cases. There is no short-term plan to fix the compatibility issues though any pull requests to the plugin will be appreciated.
+For Jenkins installed as a Linux systemd service:
+
+```shell
+sudo journalctl -u jenkins --since "24 hours ago" --no-pager \
+  | grep -F '[Ansible-Tower]'
 ```
 
-### Pipeline returns
+To find transient gateway failures and retries:
 
-When running under a pipeline, the EnvInject plugin is not required. The environment variables will either be:
-
-* Returned in the return object (for non-async jobs)
-* Accessible through the job object (for async jobs)
-
-The async job example can be seen above in the Pipeline Support section.
-
-For a non-async job you can access the variables as so:
-```groovy
-node {
-    stage ('deploy gitlab') {
-        wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
-            results = ansibleTower(
-                towerServer: 'Tower 3.3.0',
-                jobTemplate: 'Jenkins Export Vars',
-                importTowerLogs: true,
-                removeColor: false,
-                verbose: true,
-            )
-             
-            sh 'env' // this may not always work
-        }
-        println(results.JOB_ID)
-        println(results.value)
-    }
-}
+```shell
+sudo journalctl -u jenkins --no-pager \
+  | grep -E '\[Ansible-Tower\].*(502|503|504|attempt=|exhausted retries)'
 ```
 
-Another example could be as follows:
-```groovy
-pipeline {
-    agent any
-    environment {
-        MY_ENV_VAR='' // not recommended, only for demonstration
-    }
-    stages {
-      stage('Tower') {
-            steps{
-                script{
-                    results=ansibleTower(
-                        importTowerLogs: true,
-                        importWorkflowChildLogs: false,
-                        jobTemplate: 'Demo Set Stats template',
-                        jobType: 'run',
-                        removeColor: false,
-                        templateType: 'job',
-                        throwExceptionWhenFail: false,
-                        towerCredentialsId: '5a55e074-d8c3-474e-b0de-c2f3af738c3c',
-                        towerServer: 'infra-ansible-tower',
-                        verbose: true
-                    )
-                    print(results['vm1']);
-                    print(results.vm2);
-                    $MY_ENV_VAR=results.toString(); // not recommended
-                }
-            }
-        }
-      stage('output'){
-          steps{
-              print(results['vm1']);
-              print(results.vm2);
-              echo $MY_ENV_VAR // not recommended
-          }
-      }
-    }
-}
+Job status and workflow event polling retry HTTP 502, 503, and 504 responses up to five times with a ten-second delay. Exhausted retries are logged at `SEVERE`.
+
+### Common checks
+
+- A `401` normally indicates an invalid or expired credential.
+- A `403` normally indicates insufficient controller permissions.
+- A `404` often indicates the wrong API Base Path or a resource that does not exist.
+- Repeated `502`, `503`, or `504` responses usually point to the AAP gateway, route, load balancer, or controller availability rather than a Jenkins credential issue.
+- If launch overrides are ignored, enable the corresponding **Prompt on launch** option on the controller template.
+
+## Development
+
+Run the test suite:
+
+```shell
+mvn test
 ```
 
-In this example you can see that we are setting `results` variable and accessing it in the stage `Tower` as well as in the following stage `output`. You may skip the definition and use of `$MY_ENV_VAR`, but it is shown here as to how you can get the data in Env var. One of the disadvantage with Env var is that if you are getting return value other than a `String` (which is the case in this plugin) you may fail to set and use the env var correctly. Hence its recommended to not use Env var method.
+Build and verify the plugin:
 
-Above example of pipeline uses a playbook that looks like this:
-```
----
-- name: Set stats sample play
-  hosts: localhost
-  connection: local
-  vars:
-    vm1:
-      name: Test stats
-      vm_name: test-vm-1
-      ip_addr: 10.x.x.x
-      description: some descriptive text
-    vm2:
-      name: Test stats
-      vm_name: test-vm-2
-      ip_addr: 10.x.x.x
-      description: some descriptive text
-  tasks:
-    - name: Set stats for demo
-      set_stats:
-        data:
-          JENKINS_EXPORT:
-            - vm1: "{{ vm1 }}"
-            - vm2: "{{ vm2 }}"
+```shell
+mvn verify
 ```
 
-For a job run, there are three special variables in results:
+The HPI is generated at `target/ansible-tower.hpi`.
 
-* JOB_ID - a string containing the Tower ID number of the job
-* JOB_URL - a string containing the URL to the job in Tower
-* JOB_RESULT - a String of either SUCCESS or FAILED depending on the job status.<br/>**Note:** This variable is only applied for a non-async job.
+## Support and contributions
 
-For a project sync, there are:
-* SYNC_ID - a string containing the Tower ID number of the project sync
-* SYNC_URL - a string containing the URL to the sync job in Tower
-* SYNC_RESULT = a string of either SUCCESS or FAILED depending on the sync status.<br/>**Note:** This variable is only applied for a non-async job.
+- Report reproducible defects through [GitHub Issues](https://github.com/jenkinsci/ansible-tower-plugin/issues).
+- Review published changes in [GitHub Releases](https://github.com/jenkinsci/ansible-tower-plugin/releases).
+- Contributions should include tests for behavior changes and pass `mvn verify`.
+
+This project is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,25 @@ For local development, use JDK 21 and Maven 3.9.6 or newer.
 
 ## Installation
 
-Install **Ansible Tower** from **Manage Jenkins → Plugins**, or upload a locally built `ansible-tower.hpi` from the plugin manager's advanced settings.
+1. Open **Manage Jenkins → Plugins**.
+2. Search the **Available plugins** tab for **Ansible Tower**.
+3. Install the plugin and restart Jenkins if requested.
+4. Alternatively, upload a locally built `ansible-tower.hpi` from the plugin manager's advanced settings.
 
 After installation, configure at least one controller under **Manage Jenkins → System → Ansible Tower**.
 
 ## Global configuration
+
+1. Open **Manage Jenkins → System**.
+2. Find the **Ansible Tower** section.
+3. Select **Add Tower Installation**.
+4. Enter the installation name, URL, API Base Path, credential, and TLS/debug options.
+5. Select **Test Connection**.
+6. Save the Jenkins system configuration after the test succeeds.
+
+![Ansible Tower global configuration](./docs/images/configuration-0.7.0.png)
+
+> The screenshot is from an earlier plugin release. Current releases also display the **API Base Path** selector used for Tower/AWX and AAP 2.5+ compatibility.
 
 Each configured installation has the following fields:
 
@@ -66,6 +80,14 @@ The plugin accepts these Jenkins credential types:
 
 ### Username with password
 
+To configure username/password authentication:
+
+1. Open **Manage Jenkins → Credentials**.
+2. Add a **Username with password** credential.
+3. Use a dedicated controller service account with only the required permissions.
+4. Select the new credential in the global Ansible Tower installation.
+5. Use **Test Connection** to validate it.
+
 When a username/password credential is selected, the plugin attempts authentication in this order:
 
 1. Create an OAuth token.
@@ -76,6 +98,15 @@ The account should be a dedicated service account with only the permissions requ
 
 ### Secret text bearer token
 
+To configure a pre-created bearer token:
+
+1. Create an OAuth access token for the Jenkins service account in Tower, AWX, or AAP.
+2. Copy the access token value when the controller displays it.
+3. Open **Manage Jenkins → Credentials**.
+4. Add a **Secret text** credential and paste the access token into **Secret**.
+5. Select the new credential in the global Ansible Tower installation.
+6. Use **Test Connection** to validate it.
+
 Store the actual OAuth access token value in a Jenkins **Secret text** credential. The plugin sends it as a bearer token and does not create or delete that externally managed token.
 
 Secret text credentials require the [Plain Credentials Plugin](https://plugins.jenkins.io/plain-credentials/).
@@ -85,6 +116,20 @@ Do not enter a token database ID or token record ID; Jenkins needs the access to
 ## Run a job or workflow template
 
 Freestyle projects provide an **Ansible Tower** build step. Pipeline jobs use `ansibleTower`.
+
+### Freestyle configuration
+
+1. Open or create a Freestyle project.
+2. Select **Configure**.
+3. Under **Build Steps**, select **Add build step → Ansible Tower**.
+4. Choose the configured Tower/AWX/AAP server and optional credential override.
+5. Select `job` or `workflow`, then enter the template name or numeric ID.
+6. Configure launch overrides and output import behavior as required.
+7. Save and run the project.
+
+![Run an Ansible Tower job from a Freestyle project](./docs/images/run_job_freestyle.png)
+
+### Pipeline configuration
 
 The minimum Pipeline configuration is `towerServer`, `towerCredentialsId`, `jobTemplate`, and `jobType`. `towerCredentialsId` may be an empty string to use the globally configured credential.
 
@@ -152,6 +197,19 @@ The legacy Boolean `importTowerLogs` option remains supported for compatibility,
 
 Freestyle projects provide **Ansible Tower Project Sync**. Pipeline jobs use `ansibleTowerProjectSync`:
 
+For a Freestyle project:
+
+1. Open the project configuration.
+2. Select **Add build step → Ansible Tower Project Sync**.
+3. Choose the Tower server and optional credential override.
+4. Enter the controller project name.
+5. Select output, color, failure, and async behavior.
+6. Save and run the project.
+
+![Synchronize an Ansible Tower project from Freestyle](./docs/images/project_sync_freestyle.png)
+
+Pipeline example:
+
 ```groovy
 def result = ansibleTowerProjectSync(
     towerServer: 'AAP UAT',
@@ -171,6 +229,19 @@ echo "Result: ${result.SYNC_RESULT}"
 ### Project revision
 
 Freestyle projects provide **Ansible Tower Project Revision**. Pipeline jobs use `ansibleTowerProjectRevision`:
+
+For a Freestyle project:
+
+1. Open the project configuration.
+2. Select **Add build step → Ansible Tower Project Revision**.
+3. Choose the Tower server and optional credential override.
+4. Enter the project name and desired SCM revision.
+5. Select failure and verbose behavior.
+6. Save and run the project.
+
+![Change an Ansible Tower project revision from Freestyle](./docs/images/project_revision_freestyle.png)
+
+Pipeline example:
 
 ```groovy
 ansibleTowerProjectRevision(

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ release: "${BUILD_TAG}"
 
 echo "AAP job ${result.JOB_ID}: ${result.JOB_URL}"
 echo "Result: ${result.JOB_RESULT}"
+echo "Log import: ${result.LOG_IMPORT_RESULT}"
 ```
 
 ### Parameters
@@ -264,6 +265,7 @@ An asynchronous `ansibleTower` result contains:
 
 - `JOB_ID`
 - `JOB_URL`
+- `LOG_IMPORT_RESULT` with value `DEFERRED`
 - `job`, a `TowerJob` handle
 
 ```groovy
@@ -310,7 +312,12 @@ Synchronous job results are returned as a `Properties`-like object containing:
 | `JOB_ID` | Always after launch | Controller job ID. |
 | `JOB_URL` | Always after launch | Link to controller job output. |
 | `JOB_RESULT` | Synchronous execution | `SUCCESS` or `FAILED`. |
+| `LOG_IMPORT_RESULT` | Always after launch | `SKIPPED`, `DEFERRED`, `SUCCESS`, or `PARTIAL`. |
 | Exported keys | After export processing | Values produced through `JENKINS_EXPORT`. |
+
+`JOB_RESULT` reflects only the final AAP job result. Event import is best-effort: if AAP
+finishes successfully while its event or workflow-node endpoints remain unavailable,
+the step returns `JOB_RESULT=SUCCESS` and `LOG_IMPORT_RESULT=PARTIAL`.
 
 Project sync results similarly contain `SYNC_ID`, `SYNC_URL`, and, for synchronous execution, `SYNC_RESULT`.
 
@@ -393,7 +400,16 @@ sudo journalctl -u jenkins --no-pager \
   | grep -E '\[Ansible-Tower\].*(502|503|504|attempt=|exhausted retries)'
 ```
 
-Job status and workflow event polling retry HTTP 502, 503, and 504 responses up to five times with a ten-second delay. Exhausted retries are logged at `SEVERE`.
+Synchronous jobs poll status every five seconds and events every ten seconds. Status
+HTTP 502, 503, and 504 responses back off for 5, 10, 20, 30, and 30 seconds before
+the status path fails. Event failures use an independent 10, 20, then 30-second
+backoff and never delay status polling. After completion, event import is attempted
+immediately and, for transient failures, again after two and five seconds.
+
+All controller HTTP clients use a 10-second connect timeout, a 10-second connection
+pool timeout, and a 30-second read timeout. Transport timeouts, refused/reset
+connections, and empty HTTP responses are treated as transient; TLS, URL, and
+configuration errors are not.
 
 ### Common checks
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ def result = ansibleTower(
     templateType: 'job',
     towerLogLevel: 'full',
     extraVars: '''---
-environment: uat
+deployment_environment: uat
 release: "${BUILD_TAG}"
 ''',
     inventory: 'UAT Inventory',
@@ -151,9 +151,9 @@ release: "${BUILD_TAG}"
     async: false
 )
 
-echo "AAP job ${result.JOB_ID}: ${result.JOB_URL}"
-echo "Result: ${result.JOB_RESULT}"
-echo "Log import: ${result.LOG_IMPORT_RESULT}"
+// The step currently returns java.util.Properties. Printing the whole result is
+// Sandbox-safe and includes JOB_ID, JOB_URL, JOB_RESULT, and LOG_IMPORT_RESULT.
+echo "AAP result: ${result}"
 ```
 
 ### Parameters
@@ -223,8 +223,7 @@ def result = ansibleTowerProjectSync(
     verbose: false
 )
 
-echo "Sync ${result.SYNC_ID}: ${result.SYNC_URL}"
-echo "Result: ${result.SYNC_RESULT}"
+echo "Project sync result: ${result}"
 ```
 
 ### Project revision
@@ -268,6 +267,12 @@ An asynchronous `ansibleTower` result contains:
 - `LOG_IMPORT_RESULT` with value `DEFERRED`
 - `job`, a `TowerJob` handle
 
+The advanced async example below accesses a Java object returned by the plugin.
+In a sandboxed Pipeline, an administrator must first approve
+`method java.util.Dictionary get java.lang.Object` and may also need to approve
+the `TowerJob` methods used by the Pipeline. Synchronous Pipelines do not need
+these approvals when they only print the complete result as shown above.
+
 ```groovy
 def submitted = ansibleTower(
     towerServer: 'AAP UAT',
@@ -299,13 +304,13 @@ try {
 
 An asynchronous project sync result contains `SYNC_ID`, `SYNC_URL`, and a `sync` handle. `TowerProjectSync` exposes `isComplete()`, `wasSuccessful()`, `getLogs()`, `cancelSync()`, `getURL()`, `getID()`, and `releaseToken()`.
 
-Jenkins may require Script Security approvals before untrusted Pipeline code can invoke methods on these returned Java objects.
+Jenkins may require additional Script Security approvals before untrusted Pipeline code can invoke methods on these returned Java objects.
 
 When username/password authentication creates a temporary token, async mode releases the launch token before returning. Later handle calls may acquire another token; call `releaseToken()` when the handle is no longer needed.
 
 ## Returned values
 
-Synchronous job results are returned as a `Properties`-like object containing:
+Synchronous job results are returned as a `java.util.Properties` object containing:
 
 | Key | Availability | Description |
 | --- | --- | --- |
@@ -320,6 +325,12 @@ finishes successfully while its event or workflow-node endpoints remain unavaila
 the step returns `JOB_RESULT=SUCCESS` and `LOG_IMPORT_RESULT=PARTIAL`.
 
 Project sync results similarly contain `SYNC_ID`, `SYNC_URL`, and, for synchronous execution, `SYNC_RESULT`.
+
+Groovy property access such as `result.JOB_ID`, `result['JOB_ID']`, or
+`result.get('JOB_ID')` can resolve to `java.util.Dictionary.get(Object)` and be
+rejected by Jenkins Pipeline Sandbox. Print the complete result, or have an
+administrator review and approve that signature under **Manage Jenkins →
+In-process Script Approval**.
 
 ### Export data from Ansible
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectSyncStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectSyncStep.java
@@ -23,10 +23,13 @@ import org.kohsuke.stapler.verb.POST;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
 
 public class AnsibleTowerProjectSyncStep extends AbstractStepImpl {
+    private static final Logger LOGGER = Logger.getLogger(AnsibleTowerProjectSyncStep.class.getName());
     private String towerServer              = "";
     private String towerCredentialsId       = "";
     private String project                  = "";
@@ -80,7 +83,7 @@ public class AnsibleTowerProjectSyncStep extends AbstractStepImpl {
     public void setAsync(Boolean async) { this.async = async; }
 
     public boolean isGlobalColorAllowed() {
-        System.out.println("Using the class is global color allowed");
+        LOGGER.log(Level.FINE, "Using the class-level global color setting");
         return true;
     }
 
@@ -119,7 +122,7 @@ public class AnsibleTowerProjectSyncStep extends AbstractStepImpl {
         }
 
         public boolean isGlobalColorAllowed() {
-            System.out.println("Using the descriptor is global color allowed");
+            LOGGER.log(Level.FINE, "Using the descriptor-level global color setting");
             return true;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -218,70 +218,31 @@ public class AnsibleTowerRunner {
 
         if (async) {
             towerResults.put("job", this.myJob);
+            towerResults.put("LOG_IMPORT_RESULT", JobPollingCoordinator.LOG_IMPORT_DEFERRED);
             myTowerConnection.releaseToken();
             return true;
         }
 
-        boolean jobCompleted = false;
-        // Assume the old logging behaviour (truncated logs) but we we are doing full logging or var logging then swtich to true
+        // Preserve the existing full/vars event parsing behavior.
         if (importTowerLogs.matches("full") || importTowerLogs.matches("vars")) {
             myTowerConnection.setGetFullLogs(true);
         }
-        while (!jobCompleted) {
-            if (Thread.currentThread().isInterrupted()) {
-                myTowerConnection.releaseToken();
-                return this.cancelJob(logger);
-            }
-
-            // First log any events if the user wants them
-            try {
-                this.getJobLogs(importTowerLogs, logger);
-            } catch (AnsibleTowerException e) {
-                logger.println("ERROR: Failed to get job events from tower: " + e.getMessage());
-                myTowerConnection.releaseToken();
-                return false;
-            }
-
-            try {
-                jobCompleted = this.myJob.isComplete();
-            } catch (AnsibleTowerException e) {
-                logger.println("ERROR: Failed to get job status from Tower: " + e.getMessage());
-                myTowerConnection.releaseToken();
-                return false;
-            }
-            if (!jobCompleted) {
-                if (Thread.currentThread().isInterrupted()) {
-                    myTowerConnection.releaseToken();
-                    return this.cancelJob(logger);
-                } else {
-                    try {
-                        Thread.sleep(3000);
-                    } catch (InterruptedException ie) {
-                        myTowerConnection.releaseToken();
-                        return this.cancelJob(logger);
-                    }
-                }
-            }
-        }
-        // One final log of events (if we want them)
-        // Note, that a job can complete long before Tower has finished consuming the logs. This can cause incomplete
-        //    logs within Jenkins.
+        JobPollingCoordinator.Result pollingResult;
         try {
-            this.getJobLogs(importTowerLogs, logger);
+            pollingResult = new JobPollingCoordinator(this.myJob, logger, importTowerLogs)
+                .waitForCompletion();
+        } catch (InterruptedException interrupted) {
+            boolean result = this.cancelJob(logger);
+            Thread.currentThread().interrupt();
+            return result;
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Failed to get final job events from tower: " + e.getMessage());
+            logger.println("ERROR: Failed to poll job status from Tower: " + e.getMessage());
             myTowerConnection.releaseToken();
             return false;
         }
 
-        boolean wasSuccessful;
-        try {
-            wasSuccessful = this.myJob.wasSuccessful();
-        } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Failed to get job compltion status: " + e.getMessage());
-            myTowerConnection.releaseToken();
-            return false;
-        }
+        boolean wasSuccessful = pollingResult.isSuccessful();
+        towerResults.put("LOG_IMPORT_RESULT", pollingResult.getLogImportResult());
 
         HashMap<String, String> jenkinsVariables;
         try {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerException.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerException.java
@@ -8,4 +8,8 @@ public class AnsibleTowerException extends Exception {
     public AnsibleTowerException(String message) {
         super(message);
     }
+
+    public AnsibleTowerException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerTransientException.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerTransientException.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.ansible_tower.exceptions;
+
+public class AnsibleTowerTransientException extends AnsibleTowerException {
+    private final int statusCode;
+
+    public AnsibleTowerTransientException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public AnsibleTowerTransientException(String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = -1;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/JobPollingCoordinator.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/JobPollingCoordinator.java
@@ -1,0 +1,227 @@
+package org.jenkinsci.plugins.ansible_tower.util;
+
+import java.io.PrintStream;
+import java.util.Vector;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerTransientException;
+
+public final class JobPollingCoordinator {
+    public static final String LOG_IMPORT_SKIPPED = "SKIPPED";
+    public static final String LOG_IMPORT_DEFERRED = "DEFERRED";
+    public static final String LOG_IMPORT_SUCCESS = "SUCCESS";
+    public static final String LOG_IMPORT_PARTIAL = "PARTIAL";
+
+    static final long STATUS_POLL_INTERVAL_MS = 5000L;
+    static final long LOG_POLL_INTERVAL_MS = 10000L;
+    static final long[] STATUS_RETRY_DELAYS_MS = {5000L, 10000L, 20000L, 30000L, 30000L};
+    static final long[] LOG_RETRY_DELAYS_MS = {10000L, 20000L, 30000L};
+    static final long[] FINAL_LOG_RETRY_DELAYS_MS = {2000L, 5000L};
+
+    private static final String PREFIX = "[Ansible-Tower] ";
+
+    interface Clock {
+        long currentTimeMillis();
+        void sleep(long milliseconds) throws InterruptedException;
+    }
+
+    interface JobOperations {
+        TowerJobStatus pollStatus() throws AnsibleTowerException;
+        Vector<String> pollLogs() throws AnsibleTowerException;
+    }
+
+    public static final class Result {
+        private final boolean successful;
+        private final String logImportResult;
+
+        Result(boolean successful, String logImportResult) {
+            this.successful = successful;
+            this.logImportResult = logImportResult;
+        }
+
+        public boolean isSuccessful() {
+            return successful;
+        }
+
+        public String getLogImportResult() {
+            return logImportResult;
+        }
+    }
+
+    private static final class SystemClock implements Clock {
+        @Override
+        public long currentTimeMillis() {
+            return System.nanoTime() / 1_000_000L;
+        }
+
+        @Override
+        public void sleep(long milliseconds) throws InterruptedException {
+            Thread.sleep(milliseconds);
+        }
+    }
+
+    private final JobOperations job;
+    private final PrintStream console;
+    private final TowerLogger systemLogger;
+    private final Clock clock;
+    private final String logMode;
+    private final boolean logsEnabled;
+
+    public JobPollingCoordinator(TowerJob job, PrintStream console, String logMode) {
+        this(new JobOperations() {
+            @Override
+            public TowerJobStatus pollStatus() throws AnsibleTowerException {
+                return job.pollStatusOnce();
+            }
+
+            @Override
+            public Vector<String> pollLogs() throws AnsibleTowerException {
+                return job.getLogsOnce();
+            }
+        }, console, logMode, new SystemClock(), new TowerLogger());
+    }
+
+    JobPollingCoordinator(JobOperations job, PrintStream console, String logMode, Clock clock,
+            TowerLogger systemLogger) {
+        this.job = job;
+        this.console = console;
+        this.logMode = logMode;
+        this.logsEnabled = !"false".equals(logMode);
+        this.clock = clock;
+        this.systemLogger = systemLogger;
+    }
+
+    public Result waitForCompletion() throws AnsibleTowerException, InterruptedException {
+        long nextStatusPoll = clock.currentTimeMillis();
+        long nextLogPoll = nextStatusPoll;
+        int statusFailures = 0;
+        int logFailures = 0;
+
+        while(true) {
+            if(Thread.interrupted()) {
+                throw new InterruptedException("Interrupted while polling Tower job");
+            }
+
+            long now = clock.currentTimeMillis();
+            if(now >= nextStatusPoll) {
+                try {
+                    TowerJobStatus status = job.pollStatus();
+                    if(statusFailures > 0) {
+                        recovered("job status", statusFailures);
+                    }
+                    statusFailures = 0;
+                    if(status.isCompleted()) {
+                        String logResult = logsEnabled ? importFinalLogs(logFailures) : LOG_IMPORT_SKIPPED;
+                        return new Result(!status.isFailed(), logResult);
+                    }
+                    nextStatusPoll = now + STATUS_POLL_INTERVAL_MS;
+                } catch(AnsibleTowerTransientException transientFailure) {
+                    statusFailures++;
+                    if(statusFailures > STATUS_RETRY_DELAYS_MS.length) {
+                        exhausted("job status", transientFailure, statusFailures);
+                        throw transientFailure;
+                    }
+                    long delay = STATUS_RETRY_DELAYS_MS[statusFailures - 1];
+                    retry("job status", transientFailure, statusFailures,
+                        STATUS_RETRY_DELAYS_MS.length, delay);
+                    nextStatusPoll = now + delay;
+                }
+            }
+
+            now = clock.currentTimeMillis();
+            if(logsEnabled && now >= nextLogPoll) {
+                try {
+                    printEvents(job.pollLogs());
+                    if(logFailures > 0) {
+                        recovered("job events", logFailures);
+                    }
+                    logFailures = 0;
+                    nextLogPoll = now + LOG_POLL_INTERVAL_MS;
+                } catch(AnsibleTowerTransientException transientFailure) {
+                    logFailures++;
+                    int delayIndex = Math.min(logFailures - 1, LOG_RETRY_DELAYS_MS.length - 1);
+                    long delay = LOG_RETRY_DELAYS_MS[delayIndex];
+                    retry("job events", transientFailure, logFailures, -1, delay);
+                    nextLogPoll = now + delay;
+                } catch(AnsibleTowerException permanentLogFailure) {
+                    warn("Job event import failed and will be retried after completion: "
+                        + permanentLogFailure.getMessage());
+                    logFailures++;
+                    nextLogPoll = Long.MAX_VALUE;
+                }
+            }
+
+            long nextWakeup = Math.min(nextStatusPoll, logsEnabled ? nextLogPoll : Long.MAX_VALUE);
+            long sleepMillis = Math.max(1L, nextWakeup - clock.currentTimeMillis());
+            clock.sleep(sleepMillis);
+        }
+    }
+
+    private String importFinalLogs(int previousFailures) throws InterruptedException {
+        for(int attempt = 0; attempt <= FINAL_LOG_RETRY_DELAYS_MS.length; attempt++) {
+            try {
+                printEvents(job.pollLogs());
+                if(previousFailures + attempt > 0) {
+                    recovered("final job events", previousFailures + attempt);
+                }
+                return LOG_IMPORT_SUCCESS;
+            } catch(AnsibleTowerTransientException transientFailure) {
+                if(attempt == FINAL_LOG_RETRY_DELAYS_MS.length) {
+                    warn("final job events exhausted retries; AAP job completed, but event import "
+                        + "is incomplete after " + (attempt + 1) + " final attempts: "
+                        + describe(transientFailure));
+                    return LOG_IMPORT_PARTIAL;
+                }
+                long delay = FINAL_LOG_RETRY_DELAYS_MS[attempt];
+                retry("final job events", transientFailure, attempt + 1,
+                    FINAL_LOG_RETRY_DELAYS_MS.length, delay);
+                clock.sleep(delay);
+            } catch(AnsibleTowerException permanentFailure) {
+                warn("AAP job completed, but final event import is incomplete: "
+                    + permanentFailure.getMessage());
+                return LOG_IMPORT_PARTIAL;
+            }
+        }
+        return LOG_IMPORT_PARTIAL;
+    }
+
+    private void printEvents(Vector<String> events) {
+        if("vars".equals(logMode)) {
+            return;
+        }
+        for(String event : events) {
+            console.println(event);
+        }
+    }
+
+    private void retry(String operation, AnsibleTowerTransientException failure, int attempt,
+            int maximumAttempts, long delay) {
+        String maximum = maximumAttempts < 0 ? "ongoing" : Integer.toString(maximumAttempts);
+        warn(operation + " request failed: " + describe(failure) + ", retry=" + attempt + "/"
+            + maximum + ", retryDelayMs=" + delay);
+    }
+
+    private void recovered(String operation, int failures) {
+        String message = operation + " request recovered after " + failures + " transient failure(s)";
+        systemLogger.info(message);
+        console.println(PREFIX + "INFO: " + message);
+    }
+
+    private void exhausted(String operation, AnsibleTowerTransientException failure, int attempts) {
+        String message = operation + " request exhausted retries after " + attempts
+            + " attempts: " + describe(failure);
+        systemLogger.severe(message);
+        console.println(PREFIX + "ERROR: " + message);
+    }
+
+    private void warn(String message) {
+        systemLogger.warning(message);
+        console.println(PREFIX + "WARNING: " + message);
+    }
+
+    private static String describe(AnsibleTowerTransientException failure) {
+        if(failure.getStatusCode() > 0) {
+            return failure.getMessage() + ", httpStatus=" + failure.getStatusCode();
+        }
+        return failure.getMessage();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -6,7 +6,6 @@ package org.jenkinsci.plugins.ansible_tower.util;
 
 import com.google.common.net.HttpHeaders;
 import net.sf.json.JSONArray;
-import org.apache.http.Header;
 import org.apache.http.client.methods.*;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerDoesNotSupportAuthToken;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRefusesToGiveToken;
@@ -90,11 +89,11 @@ public class TowerConnector implements Serializable {
         this.setDebug(debug);
         try {
             this.getVersion();
-            logger.logMessage("Connecting to Tower version: "+ this.towerVersion.getVersion());
+            logger.info("Connected to Tower: version=" + this.towerVersion.getVersion());
         } catch(AnsibleTowerException ate) {
-            logger.logMessage("Failed to get connection to get version; auth errors may ensue "+ ate);
+            logger.warning("Unable to determine Tower version: " + ate.getMessage());
         }
-        logger.logMessage("Created a connector with "+ username +"@"+ url);
+        logger.debug("Created Tower connector: url=" + url);
     }
 
     public void setTrustAllCerts(boolean trustAllCerts) {
@@ -141,7 +140,7 @@ public class TowerConnector implements Serializable {
         }
 
         if(trustAllCerts && myURI.getScheme().equalsIgnoreCase("https")) {
-            logger.logMessage("Forcing cert trust");
+            logger.debug("Forcing cert trust");
             TrustingSSLSocketFactory sf;
             try {
                 KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -252,7 +251,7 @@ public class TowerConnector implements Serializable {
             throw new AnsibleTowerException("URL issue: "+ e.getMessage());
         }
 
-        logger.logMessage("Building "+ getMethodName(requestType) +" request to "+ myURI.toString());
+        logger.debug("Building "+ getMethodName(requestType) +" request to "+ myURI.toString());
 
         HttpUriRequest request;
         if(requestType == GET) {
@@ -277,32 +276,32 @@ public class TowerConnector implements Serializable {
         if(!noAuth) {
             if(this.authorizationHeader == null) {
                 // We dont' have an authorization header yet so we need to construct one
-                logger.logMessage("Determining authorization headers");
+                logger.debug("Determining authorization headers");
 
                 if(this.oauthToken != null) {
                     // First if we have an oauthToken we can just use it
-                    logger.logMessage("Adding oauth bearer token from Jenkins");
+                    logger.debug("Adding oauth bearer token from Jenkins");
                     this.authorizationHeader = "Bearer "+ this.oauthToken;
                 } else if(this.username != null && this.password != null) {
                     // Second, if we have a username and a password we can try to go get a token
 
                     // AAP controller mode uses the gateway token endpoint directly. Legacy Tower/AWX still probes /api/o/.
                     if (!shouldProbeOAuthSupport(this.apiBasePath) || this.towerSupports("/api/o/")) {
-                        logger.logMessage("Getting an oAuth token for "+ this.username);
+                        logger.debug("Requesting an OAuth token");
                         try {
                             this.authorizationHeader = "Bearer " + this.getOAuthToken();
                         } catch(AnsibleTowerException ate) {
-                            logger.logMessage("Unable to get oAuth Toekn: "+ ate.getMessage());
+                            logger.warning("Unable to get OAuth token: " + ate.getMessage());
                         }
                     }
 
                     // Second, we will try to get a legacy authtoken if Tower supports if
                     if(this.authorizationHeader == null && this.towerSupports(this.buildEndpoint("/authtoken/"))) {
-                        logger.logMessage("Getting a legacy token for " + this.username);
+                        logger.debug("Requesting a legacy auth token");
                         try {
                             this.authorizationHeader = "Token " + this.getAuthToken();
                         } catch (AnsibleTowerException ate) {
-                            logger.logMessage("Unable to get legacuy token: " + ate.getMessage());
+                            logger.warning("Unable to get legacy auth token: " + ate.getMessage());
                         }
                     }
 
@@ -331,7 +330,7 @@ public class TowerConnector implements Serializable {
                     */
 
                     if (this.authorizationHeader == null) {
-                        logger.logMessage("Tower does not support authtoken or oauth, reverting to basic auth");
+                        logger.debug("Tower does not support authtoken or oauth, reverting to basic auth");
                         this.authorizationHeader = this.getBasicAuthString();
                     }
                 } else {
@@ -346,9 +345,6 @@ public class TowerConnector implements Serializable {
             request.setHeader(HttpHeaders.AUTHORIZATION, this.authorizationHeader);
         }
 
-        // Dump the request
-        // logger.logMessage(this.dumpRequest(request));
-
         DefaultHttpClient httpClient = getHttpClient();
         HttpResponse response;
         try {
@@ -357,18 +353,24 @@ public class TowerConnector implements Serializable {
             throw new AnsibleTowerException("Unable to make tower request: "+ e.getMessage());
         }
 
-        logger.logMessage("Request completed with ("+ response.getStatusLine().getStatusCode() +")");
-        if(response.getStatusLine().getStatusCode() == 404) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        String responseMetadata = "HTTP request completed: method=" + getMethodName(requestType)
+            + ", endpoint=" + buildEndpoint(endpoint) + ", httpStatus=" + statusCode;
+        if(statusCode >= 400) {
+            logger.warning(responseMetadata);
+        } else {
+            logger.debug(responseMetadata);
+        }
+        if(statusCode == 404) {
             throw new AnsibleTowerItemDoesNotExist("The item does not exist");
-        } else if(response.getStatusLine().getStatusCode() == 401) {
+        } else if(statusCode == 401) {
             throw new AnsibleTowerException("Username/password invalid");
-        } else if(response.getStatusLine().getStatusCode() == 403) {
+        } else if(statusCode == 403) {
             String exceptionText = "Request was forbidden";
             JSONObject responseObject = null;
             String json;
             try {
                 json = EntityUtils.toString(response.getEntity());
-                logger.logMessage(json);
                 responseObject = JSONObject.fromObject(json);
                 if(responseObject.containsKey("detail")) {
                     exceptionText+= ": "+ responseObject.getString("detail");
@@ -383,22 +385,6 @@ public class TowerConnector implements Serializable {
         return response;
     }
 
-
-    private String dumpRequest(HttpUriRequest theRequest) {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("Request Method = [" + theRequest.getMethod() + "], ");
-        sb.append("Request URL Path = [" + theRequest.getURI()+ "], ");
-
-        sb.append("[headers]");
-        for(Header aHeader : theRequest.getAllHeaders()) {
-            sb.append("    "+ aHeader.getName() +": "+ aHeader.getValue());
-        }
-
-        return sb.toString();
-    }
-
-
     private boolean towerSupports(String end_point) throws AnsibleTowerException {
         // To determine if we support oAuth we will be making a HEAD call to /api/o to see what happens
 
@@ -409,7 +395,7 @@ public class TowerConnector implements Serializable {
             throw new AnsibleTowerException("Unable to construct URL for "+ end_point +": "+ e.getMessage());
         }
 
-        logger.logMessage("Checking if Tower can: "+ myURI.toString());
+        logger.debug("Checking if Tower can: "+ myURI.toString());
 
         DefaultHttpClient httpClient = getHttpClient();
         HttpResponse response;
@@ -419,12 +405,12 @@ public class TowerConnector implements Serializable {
             throw new AnsibleTowerException("Unable to make Tower HEAD request for "+ end_point +": "+ e.getMessage());
         }
 
-        logger.logMessage("Can Tower request completed with ("+ response.getStatusLine().getStatusCode() +")");
+        logger.debug("Can Tower request completed with ("+ response.getStatusLine().getStatusCode() +")");
         if(response.getStatusLine().getStatusCode() == 404) {
-            logger.logMessage("Tower does not supoort "+ end_point);
+            logger.debug("Tower does not supoort "+ end_point);
             return false;
         } else {
-            logger.logMessage("Tower supoorts "+ end_point);
+            logger.debug("Tower supoorts "+ end_point);
             return true;
         }
     }
@@ -436,7 +422,7 @@ public class TowerConnector implements Serializable {
         if(response.getStatusLine().getStatusCode() != 200) {
             throw new AnsibleTowerException("Unexpected error code returned from ping connection ("+ response.getStatusLine().getStatusCode() +")");
         }
-        logger.logMessage("Ping page loaded");
+        logger.debug("Ping page loaded");
 
         JSONObject responseObject;
         String json;
@@ -448,7 +434,7 @@ public class TowerConnector implements Serializable {
         }
 
         if (responseObject.containsKey("version")) {
-            logger.logMessage("Successfully got version "+ responseObject.getString("version"));
+            logger.debug("Successfully got version "+ responseObject.getString("version"));
             this.towerVersion = new TowerVersion(responseObject.getString("version"));
         }
     }
@@ -460,7 +446,7 @@ public class TowerConnector implements Serializable {
         // straight into calling an authentication test
 
         // This will run an authentication test
-        logger.logMessage("Testing authentication");
+        logger.debug("Testing authentication");
         HttpResponse response = makeRequest(GET, "jobs/");
         if(response.getStatusLine().getStatusCode() != 200) {
             throw new AnsibleTowerException("Failed to get authenticated connection ("+ response.getStatusLine().getStatusCode() +")");
@@ -470,7 +456,7 @@ public class TowerConnector implements Serializable {
 
     public String convertPotentialStringToID(String idToCheck, String api_endpoint) throws AnsibleTowerException, AnsibleTowerItemDoesNotExist {
         JSONObject foundItem = rawLookupByString(idToCheck, api_endpoint);
-        logger.logMessage("Response from lookup: "+ foundItem.getString("id"));
+        logger.debug("Response from lookup: "+ foundItem.getString("id"));
         return foundItem.getString("id");
     }
 
@@ -591,10 +577,10 @@ public class TowerConnector implements Serializable {
         }
 
         if (vault_credential_type == -1L) {
-            logger.logMessage("[ERROR]: Unable to find vault credential type");
+            logger.warning("Unable to find vault credential type");
         }
         if (machine_credential_type == -1L) {
-            logger.logMessage("[ERROR]: Unable to find machine credential type");
+            logger.warning("Unable to find machine credential type");
         }
         /*
             Credential can be a comma delineated list and in 2.3.x can come in three types:
@@ -724,8 +710,8 @@ public class TowerConnector implements Serializable {
             if (responseObject.containsKey("id")) {
                 return responseObject.getLong("id");
             }
-            logger.logMessage(json);
-            throw new AnsibleTowerException("Did not get an ID from the request. Template response can be found in the jenkins.log");
+            logger.severe("Tower launch response did not contain a job ID");
+            throw new AnsibleTowerException("Did not get an ID from the Tower launch response");
         } else if(response.getStatusLine().getStatusCode() == 400) {
             String json = null;
             JSONObject responseObject = null;
@@ -733,8 +719,7 @@ public class TowerConnector implements Serializable {
                 json = EntityUtils.toString(response.getEntity());
                 responseObject = JSONObject.fromObject(json);
             } catch(Exception e) {
-                logger.logMessage("Unable to parse 400 response from json to get details: "+ e.getMessage());
-                logger.logMessage(json);
+                logger.warning("Unable to parse Tower 400 response: " + e.getMessage());
             }
 
             /*
@@ -747,9 +732,9 @@ public class TowerConnector implements Serializable {
             */
 
             if(responseObject != null && responseObject.containsKey("extra_vars")) {
-                throw new AnsibleTowerException("Extra vars are bad: "+ responseObject.getString("extra_vars"));
+                throw new AnsibleTowerException("Tower rejected the supplied extra vars");
             } else {
-                throw new AnsibleTowerException("Tower received a bad request (400 response code)\n" + json);
+                throw new AnsibleTowerException("Tower received a bad request (400 response code)");
             }
         } else {
             throw new AnsibleTowerException("Unexpected error code returned ("+ response.getStatusLine().getStatusCode() +")");
@@ -774,12 +759,9 @@ public class TowerConnector implements Serializable {
                 && retryCount < MAX_TRANSIENT_GATEWAY_RETRIES) {
             retryCount++;
             int statusCode = response.getStatusLine().getStatusCode();
-            logger.logMessage("Job status poll failed: jobID=" + jobID
-                + ", templateType=" + templateType
-                + ", endpoint=" + buildEndpoint(apiEndpoint)
-                + ", httpStatus=" + statusCode
-                + ", retry=" + retryCount + "/" + MAX_TRANSIENT_GATEWAY_RETRIES
-                + ", retryDelaySeconds=" + (TRANSIENT_GATEWAY_RETRY_DELAY_MS / 1000L));
+            logger.warning(buildRetryLogMessage("job_status_poll", jobID, templateType,
+                buildEndpoint(apiEndpoint), statusCode, retryCount, MAX_TRANSIENT_GATEWAY_RETRIES,
+                TRANSIENT_GATEWAY_RETRY_DELAY_MS));
             EntityUtils.consumeQuietly(response.getEntity());
             try {
                 Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
@@ -789,6 +771,12 @@ public class TowerConnector implements Serializable {
                     + statusCode + " for job " + jobID);
             }
             response = makeRequest(GET, apiEndpoint);
+        }
+
+        if(isTransientGatewayStatus(response.getStatusLine().getStatusCode())) {
+            logger.severe(buildRetryExhaustedLogMessage("job_status_poll", jobID, templateType,
+                buildEndpoint(apiEndpoint), response.getStatusLine().getStatusCode(),
+                MAX_TRANSIENT_GATEWAY_RETRIES + 1));
         }
 
         if(response.getStatusLine().getStatusCode() == 200) {
@@ -808,7 +796,7 @@ public class TowerConnector implements Serializable {
                 } else {
                     // Since we were finished we will now also check for stats
                     if(responseObject.containsKey(ARTIFACTS)) {
-                        logger.logMessage("Processing artifacts");
+                        logger.debug("Processing artifacts");
                         JSONObject artifacts = responseObject.getJSONObject(ARTIFACTS);
                         if(artifacts.containsKey("JENKINS_EXPORT")) {
                             JSONArray exportVariables = artifacts.getJSONArray("JENKINS_EXPORT");
@@ -826,8 +814,9 @@ public class TowerConnector implements Serializable {
                     return true;
                 }
             }
-            logger.logMessage(json);
-            throw new AnsibleTowerException("Did not get a failed status from the request. Job response can be found in the jenkins.log");
+            logger.severe("Tower job status response did not contain finished: jobId=" + jobID
+                + ", templateType=" + templateType);
+            throw new AnsibleTowerException("Tower job response did not contain a finished status");
         } else {
             throw new AnsibleTowerException("Unexpected error code returned (" + response.getStatusLine().getStatusCode() + ")");
         }
@@ -835,6 +824,25 @@ public class TowerConnector implements Serializable {
 
     static boolean isTransientGatewayStatus(int statusCode) {
         return statusCode == 502 || statusCode == 503 || statusCode == 504;
+    }
+
+    static String buildRetryLogMessage(String operation, long jobID, String templateType, String endpoint,
+            int statusCode, int attempt, int maxAttempts, long retryDelayMs) {
+        return operation + " failed: jobId=" + jobID
+            + ", templateType=" + templateType
+            + ", endpoint=" + endpoint
+            + ", httpStatus=" + statusCode
+            + ", attempt=" + attempt + "/" + maxAttempts
+            + ", retryDelayMs=" + retryDelayMs;
+    }
+
+    static String buildRetryExhaustedLogMessage(String operation, long jobID, String templateType,
+            String endpoint, int statusCode, int attempts) {
+        return operation + " exhausted retries: jobId=" + jobID
+            + ", templateType=" + templateType
+            + ", endpoint=" + endpoint
+            + ", httpStatus=" + statusCode
+            + ", attempts=" + attempts;
     }
 
     public void cancelJob(long jobID, String templateType) throws AnsibleTowerException {
@@ -935,11 +943,9 @@ public class TowerConnector implements Serializable {
                 && retryCount < MAX_TRANSIENT_GATEWAY_RETRIES) {
             retryCount++;
             int statusCode = response.getStatusLine().getStatusCode();
-            logger.logMessage("Workflow events poll failed: jobID=" + jobID
-                + ", endpoint=" + buildEndpoint(apiEndpoint)
-                + ", httpStatus=" + statusCode
-                + ", retry=" + retryCount + "/" + MAX_TRANSIENT_GATEWAY_RETRIES
-                + ", retryDelaySeconds=" + (TRANSIENT_GATEWAY_RETRY_DELAY_MS / 1000L));
+            logger.warning(buildRetryLogMessage("workflow_events_poll", jobID, WORKFLOW_TEMPLATE_TYPE,
+                buildEndpoint(apiEndpoint), statusCode, retryCount, MAX_TRANSIENT_GATEWAY_RETRIES,
+                TRANSIENT_GATEWAY_RETRY_DELAY_MS));
             EntityUtils.consumeQuietly(response.getEntity());
             try {
                 Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
@@ -949,6 +955,12 @@ public class TowerConnector implements Serializable {
                     + statusCode + " for job " + jobID);
             }
             response = makeRequest(GET, apiEndpoint);
+        }
+
+        if(isTransientGatewayStatus(response.getStatusLine().getStatusCode())) {
+            logger.severe(buildRetryExhaustedLogMessage("workflow_events_poll", jobID,
+                WORKFLOW_TEMPLATE_TYPE, buildEndpoint(apiEndpoint),
+                response.getStatusLine().getStatusCode(), MAX_TRANSIENT_GATEWAY_RETRIES + 1));
         }
 
         if(response.getStatusLine().getStatusCode() == 200) {
@@ -961,9 +973,9 @@ public class TowerConnector implements Serializable {
                 throw new AnsibleTowerException("Unable to read response and convert it into json: "+ ioe.getMessage());
             }
 
-            logger.logMessage(json);
-
             if(responseObject.containsKey("results")) {
+                logger.debug("Workflow events received: jobId=" + jobID
+                    + ", resultCount=" + responseObject.getJSONArray("results").size());
                 for(Object anEventObject : responseObject.getJSONArray("results")) {
                     JSONObject anEvent = (JSONObject) anEventObject;
                     long eventId = anEvent.getLong("id");
@@ -1061,7 +1073,8 @@ public class TowerConnector implements Serializable {
                 throw new AnsibleTowerException("Unable to read response and convert it into json: "+ ioe.getMessage());
             }
 
-            logger.logMessage(json);
+            logger.debug("Inventory sync output received: syncId=" + syncID
+                + ", hasStdout=" + responseObject.containsKey("result_stdout"));
 
             if(responseObject.containsKey("result_stdout")) {
                 events.addAll(logLine(responseObject.getString("result_stdout")));
@@ -1088,7 +1101,8 @@ public class TowerConnector implements Serializable {
                 throw new AnsibleTowerException("Unable to read response and convert it into json: "+ ioe.getMessage());
             }
 
-            logger.logMessage(json);
+            logger.debug("Project sync output received: syncId=" + syncID
+                + ", hasStdout=" + responseObject.containsKey("result_stdout"));
 
             if(responseObject.containsKey("result_stdout")) {
                 events.addAll(logLine(responseObject.getString("result_stdout")));
@@ -1117,12 +1131,12 @@ public class TowerConnector implements Serializable {
                     throw new AnsibleTowerException("Unable to read response and convert it into json: " + ioe.getMessage());
                 }
 
-                logger.logMessage(json);
-
                 if(responseObject.containsKey("next") && responseObject.getString("next") == null || responseObject.getString("next").equalsIgnoreCase("null")) {
                     keepChecking = false;
                 }
                 if (responseObject.containsKey("results")) {
+                    logger.debug("Job events received: jobId=" + jobID
+                        + ", resultCount=" + responseObject.getJSONArray("results").size());
                     for (Object anEvent : responseObject.getJSONArray("results")) {
                         JSONObject eventObject = (JSONObject) anEvent;
                         long eventId = eventObject.getLong("id");
@@ -1170,8 +1184,9 @@ public class TowerConnector implements Serializable {
             if (responseObject.containsKey("failed")) {
                 return responseObject.getBoolean("failed");
             }
-            logger.logMessage(json);
-            throw new AnsibleTowerException("Did not get a failed status from the request. Job response can be found in the jenkins.log");
+            logger.severe("Tower job response did not contain failed: jobId=" + jobID
+                + ", templateType=" + templateType);
+            throw new AnsibleTowerException("Tower job response did not contain a failed status");
         } else {
             throw new AnsibleTowerException("Unexpected error code returned (" + response.getStatusLine().getStatusCode() + ")");
         }
@@ -1207,7 +1222,7 @@ public class TowerConnector implements Serializable {
         DefaultHttpClient httpClient = getHttpClient();
         HttpResponse response;
         try {
-            logger.logMessage("Calling for oauth token at "+ tokenURI);
+            logger.debug("Calling for oauth token at "+ tokenURI);
             response = httpClient.execute(oauthTokenRequest);
         } catch(Exception e) {
             throw new AnsibleTowerException("Unable to make request for an oauth token: "+ e.getMessage());
@@ -1238,15 +1253,15 @@ public class TowerConnector implements Serializable {
         }
 
         if (responseObject.containsKey("token")) {
-            logger.logMessage("AuthToken acquired ("+ this.oAuthTokenID +")");
+            logger.debug("OAuth token acquired");
             return responseObject.getString("token");
         }
-        logger.logMessage(json);
-        throw new AnsibleTowerException("Did not get an oauth token from the request. Template response can be found in the jenkins.log");
+        logger.severe("OAuth token response did not contain a token");
+        throw new AnsibleTowerException("OAuth token response did not contain a token");
     }
 
     private String getAuthToken() throws AnsibleTowerException {
-        logger.logMessage("Getting auth token for "+ this.username);
+        logger.debug("Requesting auth token");
 
         String tokenURI = url + this.buildEndpoint("/authtoken/");
         HttpPost tokenRequest = new HttpPost(tokenURI);
@@ -1261,7 +1276,7 @@ public class TowerConnector implements Serializable {
         DefaultHttpClient httpClient = getHttpClient();
         HttpResponse response;
         try {
-            logger.logMessage("Calling for token at "+ tokenURI);
+            logger.debug("Calling for token at "+ tokenURI);
             response = httpClient.execute(tokenRequest);
         } catch(Exception e) {
             throw new AnsibleTowerException("Unable to make request for an authtoken: "+ e.getMessage());
@@ -1285,16 +1300,16 @@ public class TowerConnector implements Serializable {
         }
 
         if (responseObject.containsKey("token")) {
-            logger.logMessage("AuthToken acquired");
+            logger.debug("AuthToken acquired");
             return responseObject.getString("token");
         }
-        logger.logMessage(json);
-        throw new AnsibleTowerException("Did not get a token from the request. Template response can be found in the jenkins.log");
+        logger.severe("Auth token response did not contain a token");
+        throw new AnsibleTowerException("Auth token response did not contain a token");
     }
 
     public void releaseToken() {
         if(this.oAuthTokenID != null) {
-            logger.logMessage("Deleting oAuth token "+ this.oAuthTokenID +" for " + this.username);
+            logger.debug("Deleting OAuth token");
             try {
                 String tokenEndpoint = this.oAuthTokenBaseEndpoint;
                 if(tokenEndpoint == null) {
@@ -1305,20 +1320,21 @@ public class TowerConnector implements Serializable {
                 tokenRequest.setHeader(HttpHeaders.AUTHORIZATION, this.getBasicAuthString());
 
                 DefaultHttpClient httpClient = getHttpClient();
-                logger.logMessage("Calling for oAuth token delete at " + tokenURI);
+                logger.debug("Calling OAuth token delete: endpoint=" + tokenEndpoint);
                 HttpResponse response = httpClient.execute(tokenRequest);
                 if(response.getStatusLine().getStatusCode() == 400) {
-                    logger.logMessage("Unable to delete oAuthToken: Invalid Authorization");
+                    logger.warning("Unable to delete OAuth token: invalid authorization");
                 } else if(response.getStatusLine().getStatusCode() != 204) {
-                    logger.logMessage("Unable to delete oauth token, server responded with ("+ response.getStatusLine().getStatusCode() +")");
+                    logger.warning("Unable to delete OAuth token: httpStatus="
+                        + response.getStatusLine().getStatusCode());
                 }
-                logger.logMessage("oAuth Token deleted");
+                logger.debug("oAuth Token deleted");
 
                 this.oAuthTokenID = null;
                 this.oAuthTokenBaseEndpoint = null;
                 this.authorizationHeader = null;
             } catch(Exception e) {
-                logger.logMessage("Failed to delete token: "+ e.getMessage());
+                logger.warning("Failed to delete OAuth token: " + e.getMessage());
             }
 
         }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -10,9 +10,13 @@ import org.apache.http.client.methods.*;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerDoesNotSupportAuthToken;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRefusesToGiveToken;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerTransientException;
 
 import java.io.*;
 import java.net.URI;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
@@ -36,6 +40,8 @@ import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.conn.params.ConnManagerParams;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.util.EntityUtils;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerItemDoesNotExist;
@@ -66,8 +72,9 @@ public class TowerConnector implements Serializable {
     private boolean trustAllCerts = true;
     private boolean importChildWorkflowLogs = false;
     private TowerLogger logger = new TowerLogger();
-    private HashMap<Long, Long> logIdForWorkflows = new HashMap<Long, Long>();
+    private HashMap<Long, Set<Long>> processedWorkflowNodeIds = new HashMap<Long, Set<Long>>();
     private HashMap<Long, Long> logIdForJobs = new HashMap<Long, Long>();
+    private HashMap<Long, Boolean> completedJobFailures = new HashMap<Long, Boolean>();
 
     private boolean removeColor = true;
     private boolean getFullLogs = false;
@@ -139,6 +146,8 @@ public class TowerConnector implements Serializable {
             throw new AnsibleTowerException("Unable to prase base url: "+ urise);
         }
 
+        HttpParams params = new BasicHttpParams();
+        configureHttpTimeouts(params);
         if(trustAllCerts && myURI.getScheme().equalsIgnoreCase("https")) {
             logger.debug("Forcing cert trust");
             TrustingSSLSocketFactory sf;
@@ -151,7 +160,6 @@ public class TowerConnector implements Serializable {
             }
             sf.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
 
-            HttpParams params = new BasicHttpParams();
             HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
             HttpProtocolParams.setContentCharset(params, HTTP.UTF_8);
 
@@ -162,8 +170,14 @@ public class TowerConnector implements Serializable {
 
             return new DefaultHttpClient(ccm, params);
         } else {
-            return new DefaultHttpClient();
+            return new DefaultHttpClient(params);
         }
+    }
+
+    static void configureHttpTimeouts(HttpParams params) {
+        HttpConnectionParams.setConnectionTimeout(params, 10000);
+        ConnManagerParams.setTimeout(params, 10000L);
+        HttpConnectionParams.setSoTimeout(params, 30000);
     }
 
     private String buildEndpoint(String endpoint) {
@@ -350,6 +364,11 @@ public class TowerConnector implements Serializable {
         try {
             response = httpClient.execute(request);
         } catch(Exception e) {
+            if(isTransientTransportFailure(e)) {
+                throw new AnsibleTowerTransientException("Transient Tower transport failure: method="
+                    + getMethodName(requestType) + ", endpoint=" + buildEndpoint(endpoint)
+                    + ", cause=" + e.getClass().getSimpleName(), e);
+            }
             throw new AnsibleTowerException("Unable to make tower request: "+ e.getMessage());
         }
 
@@ -383,6 +402,22 @@ public class TowerConnector implements Serializable {
         }
 
         return response;
+    }
+
+    static boolean isTransientTransportFailure(Throwable failure) {
+        Throwable current = failure;
+        while(current != null) {
+            if(current instanceof SocketTimeoutException || current instanceof ConnectException
+                    || current instanceof SocketException
+                    || current instanceof java.io.InterruptedIOException
+                    || "NoHttpResponseException".equals(current.getClass().getSimpleName())
+                    || "ConnectionPoolTimeoutException".equals(current.getClass().getSimpleName())
+                    || "HttpHostConnectException".equals(current.getClass().getSimpleName())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private boolean towerSupports(String end_point) throws AnsibleTowerException {
@@ -737,7 +772,8 @@ public class TowerConnector implements Serializable {
                 throw new AnsibleTowerException("Tower received a bad request (400 response code)");
             }
         } else {
-            throw new AnsibleTowerException("Unexpected error code returned ("+ response.getStatusLine().getStatusCode() +")");
+            throw new AnsibleTowerException("Unexpected error code returned ("
+                + response.getStatusLine().getStatusCode() + ")");
         }
     }
 
@@ -748,38 +784,36 @@ public class TowerConnector implements Serializable {
     }
 
     public boolean isJobCompleted(long jobID, String templateType) throws AnsibleTowerException {
-        checkTemplateType(templateType);
-
-        String apiEndpoint = "/jobs/"+ jobID +"/";
-        if(templateType.equalsIgnoreCase(WORKFLOW_TEMPLATE_TYPE)) { apiEndpoint = "/workflow_jobs/"+ jobID +"/"; }
-        HttpResponse response = makeRequest(GET, apiEndpoint);
-
         int retryCount = 0;
-        while(isTransientGatewayStatus(response.getStatusLine().getStatusCode())
-                && retryCount < MAX_TRANSIENT_GATEWAY_RETRIES) {
-            retryCount++;
-            int statusCode = response.getStatusLine().getStatusCode();
-            logger.warning(buildRetryLogMessage("job_status_poll", jobID, templateType,
-                buildEndpoint(apiEndpoint), statusCode, retryCount, MAX_TRANSIENT_GATEWAY_RETRIES,
-                TRANSIENT_GATEWAY_RETRY_DELAY_MS));
-            EntityUtils.consumeQuietly(response.getEntity());
+        while(true) {
             try {
-                Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
-            } catch(InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new AnsibleTowerException("Interrupted while retrying job status request after HTTP "
-                    + statusCode + " for job " + jobID);
+                return pollJobStatusOnce(jobID, templateType).isCompleted();
+            } catch(AnsibleTowerTransientException transientFailure) {
+                if(retryCount >= MAX_TRANSIENT_GATEWAY_RETRIES) {
+                    logger.severe("job_status_poll exhausted: jobId=" + jobID
+                        + ", templateType=" + templateType + ", attempts=" + (retryCount + 1));
+                    throw transientFailure;
+                }
+                retryCount++;
+                logger.warning(buildRetryLogMessage("job_status_poll", jobID, templateType,
+                    buildEndpoint(statusEndpoint(jobID, templateType)), transientFailure.getStatusCode(),
+                    retryCount, MAX_TRANSIENT_GATEWAY_RETRIES, TRANSIENT_GATEWAY_RETRY_DELAY_MS));
+                try {
+                    Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
+                } catch(InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new AnsibleTowerException("Interrupted while retrying job status request", interrupted);
+                }
             }
-            response = makeRequest(GET, apiEndpoint);
         }
+    }
 
-        if(isTransientGatewayStatus(response.getStatusLine().getStatusCode())) {
-            logger.severe(buildRetryExhaustedLogMessage("job_status_poll", jobID, templateType,
-                buildEndpoint(apiEndpoint), response.getStatusLine().getStatusCode(),
-                MAX_TRANSIENT_GATEWAY_RETRIES + 1));
-        }
-
-        if(response.getStatusLine().getStatusCode() == 200) {
+    TowerJobStatus pollJobStatusOnce(long jobID, String templateType) throws AnsibleTowerException {
+        checkTemplateType(templateType);
+        String apiEndpoint = statusEndpoint(jobID, templateType);
+        HttpResponse response = makeRequest(GET, apiEndpoint);
+        int statusCode = response.getStatusLine().getStatusCode();
+        if(statusCode == 200) {
             JSONObject responseObject;
             String json;
             try {
@@ -792,8 +826,9 @@ public class TowerConnector implements Serializable {
             if (responseObject.containsKey("finished")) {
                 String finished = responseObject.getString("finished");
                 if(finished == null || finished.equalsIgnoreCase("null")) {
-                    return false;
+                    return new TowerJobStatus(false, false);
                 } else {
+                    Map<String, String> statusArtifacts = new HashMap<String, String>();
                     // Since we were finished we will now also check for stats
                     if(responseObject.containsKey(ARTIFACTS)) {
                         logger.debug("Processing artifacts");
@@ -806,20 +841,38 @@ public class TowerConnector implements Serializable {
                                 Iterator<String> keyIterator = entry.keys();
                                 while(keyIterator.hasNext()) {
                                     String key = keyIterator.next();
-                                    jenkinsExports.put(key, entry.getString(key));
+                                    String value = entry.getString(key);
+                                    jenkinsExports.put(key, value);
+                                    statusArtifacts.put(key, value);
                                 }
                             }
                         }
                     }
-                    return true;
+                    if(!responseObject.containsKey("failed")) {
+                        throw new AnsibleTowerException("Tower job response did not contain a failed status");
+                    }
+                    boolean failed = responseObject.getBoolean("failed");
+                    completedJobFailures.put(jobID, failed);
+                    return new TowerJobStatus(true, failed, statusArtifacts);
                 }
             }
             logger.severe("Tower job status response did not contain finished: jobId=" + jobID
                 + ", templateType=" + templateType);
             throw new AnsibleTowerException("Tower job response did not contain a finished status");
+        } else if(isTransientGatewayStatus(statusCode)) {
+            EntityUtils.consumeQuietly(response.getEntity());
+            throw new AnsibleTowerTransientException("jobId=" + jobID + ", templateType="
+                + templateType + ", endpoint=" + buildEndpoint(apiEndpoint), statusCode);
         } else {
-            throw new AnsibleTowerException("Unexpected error code returned (" + response.getStatusLine().getStatusCode() + ")");
+            throw new AnsibleTowerException("Unexpected error code returned (" + statusCode + ")");
         }
+    }
+
+    private String statusEndpoint(long jobID, String templateType) {
+        if(templateType.equalsIgnoreCase(WORKFLOW_TEMPLATE_TYPE)) {
+            return "/workflow_jobs/" + jobID + "/";
+        }
+        return "/jobs/" + jobID + "/";
     }
 
     static boolean isTransientGatewayStatus(int statusCode) {
@@ -917,6 +970,30 @@ public class TowerConnector implements Serializable {
     }
 
     public Vector<String> getLogEvents(long jobID, String templateType) throws AnsibleTowerException {
+        int retryCount = 0;
+        while(true) {
+            try {
+                return getLogEventsOnce(jobID, templateType);
+            } catch(AnsibleTowerTransientException transientFailure) {
+                if(retryCount >= MAX_TRANSIENT_GATEWAY_RETRIES) {
+                    throw transientFailure;
+                }
+                retryCount++;
+                logger.warning("job_events_poll failed: jobId=" + jobID + ", templateType="
+                    + templateType + ", retry=" + retryCount + "/" + MAX_TRANSIENT_GATEWAY_RETRIES
+                    + ", httpStatus=" + transientFailure.getStatusCode()
+                    + ", retryDelayMs=" + TRANSIENT_GATEWAY_RETRY_DELAY_MS);
+                try {
+                    Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
+                } catch(InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new AnsibleTowerException("Interrupted while retrying job events request", interrupted);
+                }
+            }
+        }
+    }
+
+    Vector<String> getLogEventsOnce(long jobID, String templateType) throws AnsibleTowerException {
         Vector<String> events = new Vector<String>();
         checkTemplateType(templateType);
         if(templateType.equalsIgnoreCase(JOB_TEMPLATE_TYPE)) {
@@ -934,36 +1011,23 @@ public class TowerConnector implements Serializable {
 
     private Vector<String> logWorkflowEvents(long jobID, boolean importWorkflowChildLogs) throws AnsibleTowerException {
         Vector<String> events = new Vector<String>();
-        if(!this.logIdForWorkflows.containsKey(jobID)) { this.logIdForWorkflows.put(jobID, 0L); }
-        String apiEndpoint = "/workflow_jobs/"+ jobID +"/workflow_nodes/?id__gt="+this.logIdForWorkflows.get(jobID);
-        HttpResponse response = makeRequest(GET, apiEndpoint);
-
-        int retryCount = 0;
-        while(isTransientGatewayStatus(response.getStatusLine().getStatusCode())
-                && retryCount < MAX_TRANSIENT_GATEWAY_RETRIES) {
-            retryCount++;
+        Set<Long> processed = this.processedWorkflowNodeIds.get(jobID);
+        if(processed == null) {
+            processed = new HashSet<Long>();
+            this.processedWorkflowNodeIds.put(jobID, processed);
+        }
+        String apiEndpoint = "/workflow_jobs/" + jobID + "/workflow_nodes/?id__gt=0";
+        while(apiEndpoint != null) {
+            HttpResponse response = makeRequest(GET, apiEndpoint);
             int statusCode = response.getStatusLine().getStatusCode();
-            logger.warning(buildRetryLogMessage("workflow_events_poll", jobID, WORKFLOW_TEMPLATE_TYPE,
-                buildEndpoint(apiEndpoint), statusCode, retryCount, MAX_TRANSIENT_GATEWAY_RETRIES,
-                TRANSIENT_GATEWAY_RETRY_DELAY_MS));
-            EntityUtils.consumeQuietly(response.getEntity());
-            try {
-                Thread.sleep(TRANSIENT_GATEWAY_RETRY_DELAY_MS);
-            } catch(InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new AnsibleTowerException("Interrupted while retrying workflow events request after HTTP "
-                    + statusCode + " for job " + jobID);
+            if(isTransientGatewayStatus(statusCode)) {
+                EntityUtils.consumeQuietly(response.getEntity());
+                throw new AnsibleTowerTransientException("jobId=" + jobID + ", templateType=workflow"
+                    + ", endpoint=" + buildEndpoint(apiEndpoint), statusCode);
             }
-            response = makeRequest(GET, apiEndpoint);
-        }
-
-        if(isTransientGatewayStatus(response.getStatusLine().getStatusCode())) {
-            logger.severe(buildRetryExhaustedLogMessage("workflow_events_poll", jobID,
-                WORKFLOW_TEMPLATE_TYPE, buildEndpoint(apiEndpoint),
-                response.getStatusLine().getStatusCode(), MAX_TRANSIENT_GATEWAY_RETRIES + 1));
-        }
-
-        if(response.getStatusLine().getStatusCode() == 200) {
+            if(statusCode != 200) {
+                throw new AnsibleTowerException("Unexpected error code returned (" + statusCode + ")");
+            }
             JSONObject responseObject;
             String json;
             try {
@@ -979,6 +1043,7 @@ public class TowerConnector implements Serializable {
                 for(Object anEventObject : responseObject.getJSONArray("results")) {
                     JSONObject anEvent = (JSONObject) anEventObject;
                     long eventId = anEvent.getLong("id");
+                    if(processed.contains(eventId)) { continue; }
 
                     if(!anEvent.containsKey("summary_fields")) { continue; }
 
@@ -995,39 +1060,46 @@ public class TowerConnector implements Serializable {
                             job.getString("status").equalsIgnoreCase("running") ||
                             job.getString("status").equalsIgnoreCase("pending")
                     ) {
-                        // Here we want to return. Otherwise we might "loose" things.
-                        // For async_pipeline, say there are three nodes in the pipeline.
-                        // Node 1 takes a long time, Node 2 which runs in parallel is quick
-                        // If Node 2 executes second and completed we will use the ID of node 2 as the next ID.
-                        // Node 1 results will be lost because node 2 has already finished.
-                        // Returning will prevent this from happening.
-                        return events;
+                        continue;
                     }
 
-                    if(eventId > this.logIdForWorkflows.get(jobID)) { this.logIdForWorkflows.put(jobID, eventId); }
-                    events.addAll(logLine(job.getString("name") +" => "+ job.getString("status") +" "+ this.getJobURL(job.getLong("id"), templateType.getString(UNIFIED_JOB_TYPE))));
+                    Vector<String> nodeEvents = new Vector<String>();
+                    nodeEvents.addAll(logLine(job.getString("name") +" => "+ job.getString("status") +" "+ this.getJobURL(job.getLong("id"), templateType.getString(UNIFIED_JOB_TYPE))));
 
                     if(importWorkflowChildLogs) {
                         if(templateType.getString(UNIFIED_JOB_TYPE).equalsIgnoreCase("job")) {
-                            // We only need to call this once because the job is completed at this point
-                            events.addAll(logJobEvents(job.getLong("id")));
+                            nodeEvents.addAll(logJobEvents(job.getLong("id")));
                         } else if(templateType.getString(UNIFIED_JOB_TYPE).equalsIgnoreCase("project_update")) {
-                            events.addAll(logProjectSync(job.getLong("id")));
+                            nodeEvents.addAll(logProjectSync(job.getLong("id")));
                         } else if(templateType.getString(UNIFIED_JOB_TYPE).equalsIgnoreCase("inventory_update")) {
-                            events.addAll(logInventorySync(job.getLong("id")));
+                            nodeEvents.addAll(logInventorySync(job.getLong("id")));
                         } else {
-                            events.addAll(logLine("Unknown job type in workflow: "+ templateType.getString(UNIFIED_JOB_TYPE)));
+                            nodeEvents.addAll(logLine("Unknown job type in workflow: "+ templateType.getString(UNIFIED_JOB_TYPE)));
                         }
                     }
-                    // Print two spaces to put some space between this and the next task.
-                    events.addAll(logLine(""));
-                    events.addAll(logLine(""));
+                    nodeEvents.addAll(logLine(""));
+                    nodeEvents.addAll(logLine(""));
+                    processed.add(eventId);
+                    events.addAll(nodeEvents);
                 }
             }
-        } else {
-            throw new AnsibleTowerException("Unexpected error code returned ("+ response.getStatusLine().getStatusCode() +")");
+            apiEndpoint = nextPage(responseObject);
         }
         return events;
+    }
+
+    private String nextPage(JSONObject responseObject) {
+        if(!responseObject.containsKey("next") || responseObject.get("next") == null) {
+            return null;
+        }
+        String next = responseObject.getString("next");
+        if("null".equalsIgnoreCase(next) || next.isEmpty()) {
+            return null;
+        }
+        if(next.startsWith(this.url)) {
+            return next.substring(this.url.length());
+        }
+        return next;
     }
 
     public Vector<String> logLine(String output) throws AnsibleTowerException {
@@ -1080,7 +1152,8 @@ public class TowerConnector implements Serializable {
                 events.addAll(logLine(responseObject.getString("result_stdout")));
             }
         } else {
-            throw new AnsibleTowerException("Unexpected error code returned ("+ response.getStatusLine().getStatusCode() +")");
+            throw logImportFailure("inventory update: syncId=" + syncID
+                + ", endpoint=" + buildEndpoint(apiURL), response);
         }
         return events;
     }
@@ -1108,7 +1181,8 @@ public class TowerConnector implements Serializable {
                 events.addAll(logLine(responseObject.getString("result_stdout")));
             }
         } else {
-            throw new AnsibleTowerException("Unexpected error code returned ("+ response.getStatusLine().getStatusCode() +")");
+            throw logImportFailure("project update: syncId=" + syncID
+                + ", endpoint=" + buildEndpoint(apiURL), response);
         }
         return events;
     }
@@ -1116,9 +1190,9 @@ public class TowerConnector implements Serializable {
     private Vector<String> logJobEvents(long jobID) throws AnsibleTowerException {
         Vector<String> events = new Vector<String>();
         if(!this.logIdForJobs.containsKey(jobID)) { this.logIdForJobs.put(jobID, 0L); }
-        boolean keepChecking = true;
-        while(keepChecking) {
-            String apiURL = "/jobs/" + jobID + "/job_events/?id__gt="+ this.logIdForJobs.get(jobID);
+        long highestEventId = this.logIdForJobs.get(jobID);
+        String apiURL = "/jobs/" + jobID + "/job_events/?id__gt=" + highestEventId;
+        while(apiURL != null) {
             HttpResponse response = makeRequest(GET, apiURL);
 
             if (response.getStatusLine().getStatusCode() == 200) {
@@ -1131,9 +1205,6 @@ public class TowerConnector implements Serializable {
                     throw new AnsibleTowerException("Unable to read response and convert it into json: " + ioe.getMessage());
                 }
 
-                if(responseObject.containsKey("next") && responseObject.getString("next") == null || responseObject.getString("next").equalsIgnoreCase("null")) {
-                    keepChecking = false;
-                }
                 if (responseObject.containsKey("results")) {
                     logger.debug("Job events received: jobId=" + jobID
                         + ", resultCount=" + responseObject.getJSONArray("results").size());
@@ -1152,20 +1223,36 @@ public class TowerConnector implements Serializable {
                             }
                         }
                         events.addAll(logLine(stdOut));
-                        if (eventId > this.logIdForJobs.get(jobID)) {
-                            this.logIdForJobs.put(jobID, eventId);
+                        if (eventId > highestEventId) {
+                            highestEventId = eventId;
                         }
                     }
                 }
+                apiURL = nextPage(responseObject);
             } else {
-                throw new AnsibleTowerException("Unexpected error code returned (" + response.getStatusLine().getStatusCode() + ")");
+                throw logImportFailure("job events: jobId=" + jobID
+                    + ", endpoint=" + buildEndpoint(apiURL), response);
             }
         }
+        this.logIdForJobs.put(jobID, highestEventId);
         return events;
+    }
+
+    private AnsibleTowerException logImportFailure(String operation, HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        EntityUtils.consumeQuietly(response.getEntity());
+        if(isTransientGatewayStatus(statusCode)) {
+            return new AnsibleTowerTransientException(operation, statusCode);
+        }
+        return new AnsibleTowerException("Unexpected error code returned (" + statusCode + ")");
     }
 
     public boolean isJobFailed(long jobID, String templateType) throws AnsibleTowerException {
         checkTemplateType(templateType);
+
+        if(completedJobFailures.containsKey(jobID)) {
+            return completedJobFailures.get(jobID);
+        }
 
         String apiEndPoint = "/jobs/"+ jobID +"/";
         if(templateType.equalsIgnoreCase(WORKFLOW_TEMPLATE_TYPE)) { apiEndPoint = "/workflow_jobs/"+ jobID +"/"; }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
@@ -149,7 +149,8 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
         ) {
             // Also, validate that we are an Administrator
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-            TowerLogger.writeMessage("Starting to test connection with (" + towerURL + ") and (" + towerCredentialsId + ") and (" + towerTrustCert + ") with debugging (" + enableDebugging + ")");
+            TowerLogger.writeMessage("Testing Tower connection: url=" + towerURL
+                + ", trustCertificate=" + towerTrustCert + ", debugging=" + enableDebugging);
             TowerConnector testConnector = TowerInstallation.getTowerConnectorStatic(towerURL, towerCredentialsId, towerTrustCert, enableDebugging, null, towerApiBasePath);
             try {
                 testConnector.testConnection();

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerJob.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerJob.java
@@ -43,6 +43,16 @@ public class TowerJob  implements Serializable {
         return this.connection.getLogEvents(this.jobId, this.templateType);
     }
 
+    TowerJobStatus pollStatusOnce() throws AnsibleTowerException {
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
+        return connection.pollJobStatusOnce(this.jobId, this.templateType);
+    }
+
+    Vector<String> getLogsOnce() throws AnsibleTowerException {
+        if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
+        return connection.getLogEventsOnce(this.jobId, this.templateType);
+    }
+
     public HashMap<String, String> getExports() throws AnsibleTowerException {
         if(this.jobId == -1L) { throw new AnsibleTowerException("Job ID was not set"); }
         return this.connection.getJenkinsExports();

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerJobStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerJobStatus.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.ansible_tower.util;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class TowerJobStatus implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean completed;
+    private final boolean failed;
+    private final Map<String, String> artifacts;
+
+    TowerJobStatus(boolean completed, boolean failed) {
+        this(completed, failed, Collections.<String, String>emptyMap());
+    }
+
+    TowerJobStatus(boolean completed, boolean failed, Map<String, String> artifacts) {
+        this.completed = completed;
+        this.failed = failed;
+        this.artifacts = Collections.unmodifiableMap(new HashMap<String, String>(artifacts));
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public boolean isFailed() {
+        return failed;
+    }
+
+    public Map<String, String> getArtifacts() {
+        return artifacts;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
@@ -6,17 +6,47 @@ package org.jenkinsci.plugins.ansible_tower.util;
  */
 
 import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TowerLogger implements Serializable {
+    private static final Logger LOGGER = Logger.getLogger(TowerLogger.class.getName());
+    private static final String PREFIX = "[Ansible-Tower] ";
+
     private boolean debugging = false;
     public void setDebugging(boolean debugging) { this.debugging = debugging; }
+
+    /**
+     * @deprecated Use {@link #debug(String)} for diagnostic messages.
+     */
+    @Deprecated
     public void logMessage(String message) {
+        debug(message);
+    }
+
+    public void debug(String message) {
         if(debugging) {
-            writeMessage(message);
+            log(Level.FINE, message);
         }
     }
 
+    public void info(String message) {
+        log(Level.INFO, message);
+    }
+
+    public void warning(String message) {
+        log(Level.WARNING, message);
+    }
+
+    public void severe(String message) {
+        log(Level.SEVERE, message);
+    }
+
     public static void writeMessage(String message) {
-        System.out.println("[Ansible-Tower] "+ message);
+        log(Level.INFO, message);
+    }
+
+    private static void log(Level level, String message) {
+        LOGGER.log(level, "{0}{1}", new Object[] {PREFIX, message});
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerVersion.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerVersion.java
@@ -3,8 +3,11 @@ package org.jenkinsci.plugins.ansible_tower.util;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
 
 import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TowerVersion implements Serializable {
+    private static final Logger LOGGER = Logger.getLogger(TowerVersion.class.getName());
     private int major = 0;
     private int minor = 0;
     private int point = 0;
@@ -15,7 +18,7 @@ public class TowerVersion implements Serializable {
         String[] parts = version.split("\\.");
         // AWX v8.0.0 has 4 parts as in: 8.0.0.0 so instead of != 3 we should be able to do < 3 and get the same results
         if(parts.length < 3) {
-            System.out.println("Got "+ parts.length +" segments");
+            LOGGER.log(Level.FINE, "Tower version has {0} segments", parts.length);
             throw new AnsibleTowerException("The version passed to TowerVersion must be in the format X.Y.Z");
         }
         try {

--- a/src/main/webapp/help-enableDebugging.html
+++ b/src/main/webapp/help-enableDebugging.html
@@ -1,6 +1,6 @@
 <div>
-    Allow the Tower Connector class (the thing that talks to tower for all jobs) to print debugging messages to the Jenkins log (stdout).<br/>
-    This is useful for debugging connection issues.</br>
-    Messages will be prefixed with "[Ansible-Tower]" for easy finding.
-    <b>This can create alot of data as it logs requests and responses from Tower.</b></br>
+    Allow the Tower Connector class to emit detailed <code>FINE</code> diagnostics to the Jenkins logging system.<br/>
+    To view them, create a Jenkins Log Recorder for <code>org.jenkinsci.plugins.ansible_tower</code> at level <code>FINE</code> or <code>ALL</code>.<br/>
+    Operational warnings and errors are always logged. Payloads, credentials, and tokens are not logged.<br/>
+    Messages are prefixed with "[Ansible-Tower]" for easy filtering.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/JobPollingCoordinatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/JobPollingCoordinatorTest.java
@@ -1,0 +1,180 @@
+package org.jenkinsci.plugins.ansible_tower.util;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerTransientException;
+import org.junit.jupiter.api.Test;
+
+class JobPollingCoordinatorTest {
+
+    @Test
+    void transientLogsDoNotBlockStatusAndRecoverDuringFinalImport() throws Exception {
+        FakeOperations operations = new FakeOperations(
+            Arrays.asList(running(), running(), completed(false)), 2);
+
+        JobPollingCoordinator.Result result = coordinator(operations, "full").waitForCompletion();
+
+        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.getLogImportResult(), is(JobPollingCoordinator.LOG_IMPORT_SUCCESS));
+        assertThat(operations.statusCalls, is(3));
+        assertThat(operations.logCalls, is(3));
+    }
+
+    @Test
+    void exhaustedLogImportDoesNotChangeSuccessfulAapResult() throws Exception {
+        FakeOperations operations = new FakeOperations(
+            Arrays.asList(running(), completed(false)), Integer.MAX_VALUE);
+
+        JobPollingCoordinator.Result result = coordinator(operations, "full").waitForCompletion();
+
+        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.getLogImportResult(), is(JobPollingCoordinator.LOG_IMPORT_PARTIAL));
+        assertThat(operations.statusCalls, is(2));
+        assertThat(operations.logCalls, is(4));
+    }
+
+    @Test
+    void varsModeAlsoReturnsPartialWhenFinalEventsAreUnavailable() throws Exception {
+        FakeOperations operations = new FakeOperations(
+            Arrays.asList(completed(false)), Integer.MAX_VALUE);
+
+        JobPollingCoordinator.Result result = coordinator(operations, "vars").waitForCompletion();
+
+        assertThat(result.isSuccessful(), is(true));
+        assertThat(result.getLogImportResult(), is(JobPollingCoordinator.LOG_IMPORT_PARTIAL));
+    }
+
+    @Test
+    void disabledLogsAreSkippedWithoutCallingLogEndpoint() throws Exception {
+        FakeOperations operations = new FakeOperations(
+            Arrays.asList(running(), completed(false)), 0);
+
+        JobPollingCoordinator.Result result = coordinator(operations, "false").waitForCompletion();
+
+        assertThat(result.getLogImportResult(), is(JobPollingCoordinator.LOG_IMPORT_SKIPPED));
+        assertThat(operations.logCalls, is(0));
+    }
+
+    @Test
+    void aapFailureIsReturnedAsJobFailure() throws Exception {
+        FakeOperations operations = new FakeOperations(Arrays.asList(completed(true)), 0);
+
+        JobPollingCoordinator.Result result = coordinator(operations, "false").waitForCompletion();
+
+        assertThat(result.isSuccessful(), is(false));
+    }
+
+    @Test
+    void statusFailsAfterInitialRequestAndFiveRetries() {
+        FakeOperations operations = new FakeOperations(new ArrayList<TowerJobStatus>(), 0);
+        operations.statusFailures = Integer.MAX_VALUE;
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        JobPollingCoordinator coordinator = coordinator(operations, "false", output);
+
+        assertThrows(AnsibleTowerTransientException.class, coordinator::waitForCompletion);
+        assertThat(operations.statusCalls, is(6));
+        assertThat(output.toString(), containsString("exhausted retries after 6 attempts"));
+    }
+
+    @Test
+    void transientStatusRecoveryContinuesPolling() throws Exception {
+        FakeOperations operations = new FakeOperations(Arrays.asList(completed(false)), 0);
+        operations.statusFailures = 2;
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        JobPollingCoordinator.Result result = coordinator(operations, "false", output).waitForCompletion();
+
+        assertThat(result.isSuccessful(), is(true));
+        assertThat(operations.statusCalls, is(3));
+        assertThat(output.toString(), containsString("recovered after 2 transient failure(s)"));
+    }
+
+    @Test
+    void seventySecondJobStaysWithinExpectedRequestBudget() throws Exception {
+        List<TowerJobStatus> statuses = new ArrayList<TowerJobStatus>();
+        for(int i = 0; i < 14; i++) { statuses.add(running()); }
+        statuses.add(completed(false));
+        FakeOperations operations = new FakeOperations(statuses, 0);
+
+        JobPollingCoordinator.Result result = coordinator(operations, "full").waitForCompletion();
+
+        assertThat(result.isSuccessful(), is(true));
+        assertThat(operations.statusCalls, is(15));
+        assertThat(operations.logCalls, is(8));
+    }
+
+    private static JobPollingCoordinator coordinator(FakeOperations operations, String mode) {
+        return coordinator(operations, mode, new ByteArrayOutputStream());
+    }
+
+    private static JobPollingCoordinator coordinator(FakeOperations operations, String mode,
+            ByteArrayOutputStream output) {
+        return new JobPollingCoordinator(operations, new PrintStream(output), mode,
+            new FakeClock(), new TowerLogger());
+    }
+
+    private static TowerJobStatus running() {
+        return new TowerJobStatus(false, false);
+    }
+
+    private static TowerJobStatus completed(boolean failed) {
+        return new TowerJobStatus(true, failed);
+    }
+
+    private static final class FakeClock implements JobPollingCoordinator.Clock {
+        private long now;
+
+        @Override
+        public long currentTimeMillis() {
+            return now;
+        }
+
+        @Override
+        public void sleep(long milliseconds) {
+            now += milliseconds;
+        }
+    }
+
+    private static final class FakeOperations implements JobPollingCoordinator.JobOperations {
+        private final List<TowerJobStatus> statuses;
+        private final int transientLogFailures;
+        private int statusFailures;
+        private int statusCalls;
+        private int logCalls;
+
+        FakeOperations(List<TowerJobStatus> statuses, int transientLogFailures) {
+            this.statuses = statuses;
+            this.transientLogFailures = transientLogFailures;
+        }
+
+        @Override
+        public TowerJobStatus pollStatus() throws AnsibleTowerException {
+            statusCalls++;
+            if(statusCalls <= statusFailures) {
+                throw new AnsibleTowerTransientException("gateway unavailable", 503);
+            }
+            return statuses.get(Math.min(statusCalls - statusFailures - 1, statuses.size() - 1));
+        }
+
+        @Override
+        public Vector<String> pollLogs() throws AnsibleTowerException {
+            logCalls++;
+            if(logCalls <= transientLogFailures) {
+                throw new AnsibleTowerTransientException("gateway unavailable", 502);
+            }
+            Vector<String> events = new Vector<String>();
+            events.add("event " + logCalls);
+            return events;
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -161,4 +161,27 @@ class TowerConnectorTest {
         MatcherAssert.assertThat(TowerConnector.isTransientGatewayStatus(500), CoreMatchers.is(false));
         MatcherAssert.assertThat(TowerConnector.isTransientGatewayStatus(200), CoreMatchers.is(false));
     }
+
+    @Test
+    public void buildRetryLogMessage_containsOperationalMetadataWithoutPayload() {
+        String message = TowerConnector.buildRetryLogMessage(
+                "workflow_events_poll", 720828L, TowerConnector.WORKFLOW_TEMPLATE_TYPE,
+                "/api/controller/v2/workflow_jobs/720828/workflow_nodes/", 502, 1, 5, 10000L);
+
+        MatcherAssert.assertThat(message, CoreMatchers.is(
+                "workflow_events_poll failed: jobId=720828, templateType=workflow, "
+                + "endpoint=/api/controller/v2/workflow_jobs/720828/workflow_nodes/, "
+                + "httpStatus=502, attempt=1/5, retryDelayMs=10000"));
+    }
+
+    @Test
+    public void buildRetryExhaustedLogMessage_containsFinalAttemptMetadata() {
+        String message = TowerConnector.buildRetryExhaustedLogMessage(
+                "job_status_poll", 720828L, TowerConnector.JOB_TEMPLATE_TYPE,
+                "/api/controller/v2/jobs/720828/", 504, 6);
+
+        MatcherAssert.assertThat(message, CoreMatchers.is(
+                "job_status_poll exhausted retries: jobId=720828, templateType=job, "
+                + "endpoint=/api/controller/v2/jobs/720828/, httpStatus=504, attempts=6"));
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -1,14 +1,102 @@
 package org.jenkinsci.plugins.ansible_tower.util;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.SSLHandshakeException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import net.sf.json.JSONObject;
 import org.apache.http.util.EntityUtils;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.conn.params.ConnManagerParams;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 class TowerConnectorTest {
+
+    @Test
+    public void configureHttpTimeouts_appliesConnectPoolAndReadLimits() {
+        BasicHttpParams params = new BasicHttpParams();
+
+        TowerConnector.configureHttpTimeouts(params);
+
+        MatcherAssert.assertThat(HttpConnectionParams.getConnectionTimeout(params), CoreMatchers.is(10000));
+        MatcherAssert.assertThat(ConnManagerParams.getTimeout(params), CoreMatchers.is(10000L));
+        MatcherAssert.assertThat(HttpConnectionParams.getSoTimeout(params), CoreMatchers.is(30000));
+    }
+
+    @Test
+    public void transientTransportClassification_excludesTlsConfigurationFailures() {
+        MatcherAssert.assertThat(
+            TowerConnector.isTransientTransportFailure(new SocketTimeoutException("timed out")),
+            CoreMatchers.is(true));
+        MatcherAssert.assertThat(
+            TowerConnector.isTransientTransportFailure(new SSLHandshakeException("bad certificate")),
+            CoreMatchers.is(false));
+    }
+
+    @Test
+    public void workflowEvents_processCompletedParallelNodesAcrossPagesWithoutDuplicates() throws Exception {
+        AtomicInteger firstPageCalls = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v2/ping/", exchange -> respond(exchange,
+            "{\"version\":\"3.8.0\"}"));
+        server.createContext("/api/v2/workflow_jobs/7/workflow_nodes/", exchange -> {
+            if(exchange.getRequestURI().getQuery().contains("page=2")) {
+                respond(exchange, workflowPage(null, node(3, "third", "successful")));
+                return;
+            }
+            boolean firstRequest = firstPageCalls.incrementAndGet() == 1;
+            respond(exchange, workflowPage(
+                "/api/v2/workflow_jobs/7/workflow_nodes/?page=2",
+                node(1, "first", firstRequest ? "running" : "successful"),
+                node(2, "second", "successful")));
+        });
+        server.start();
+        try {
+            TowerConnector connector = new TowerConnector(
+                "http://127.0.0.1:" + server.getAddress().getPort(), null, null,
+                "test-token", false, false);
+
+            Vector<String> firstImport = connector.getLogEventsOnce(7L, TowerConnector.WORKFLOW_TEMPLATE_TYPE);
+            Vector<String> secondImport = connector.getLogEventsOnce(7L, TowerConnector.WORKFLOW_TEMPLATE_TYPE);
+
+            MatcherAssert.assertThat(firstImport.toString(), CoreMatchers.containsString("second => successful"));
+            MatcherAssert.assertThat(firstImport.toString(), CoreMatchers.containsString("third => successful"));
+            MatcherAssert.assertThat(firstImport.toString().contains("first =>"), CoreMatchers.is(false));
+            MatcherAssert.assertThat(secondImport.toString(), CoreMatchers.containsString("first => successful"));
+            MatcherAssert.assertThat(secondImport.toString().contains("second =>"), CoreMatchers.is(false));
+            MatcherAssert.assertThat(secondImport.toString().contains("third =>"), CoreMatchers.is(false));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static String node(long id, String name, String status) {
+        return "{\"id\":" + id + ",\"summary_fields\":{\"job\":{\"id\":" + (100 + id)
+            + ",\"name\":\"" + name + "\",\"status\":\"" + status
+            + "\"},\"unified_job_template\":{\"unified_job_type\":\"job\"}}}";
+    }
+
+    private static String workflowPage(String next, String... nodes) {
+        String nextValue = next == null ? "null" : "\"" + next + "\"";
+        return "{\"next\":" + nextValue + ",\"results\":[" + String.join(",", nodes) + "]}";
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        byte[] response = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, response.length);
+        try(OutputStream output = exchange.getResponseBody()) {
+            output.write(response);
+        }
+    }
 
     @Test
     public void createJsonEntity_encodesNonAsciiContentAsUtf8() throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
@@ -1,0 +1,106 @@
+package org.jenkinsci.plugins.ansible_tower.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TowerLoggerTest {
+    private final Logger julLogger = Logger.getLogger(TowerLogger.class.getName());
+    private final RecordingHandler handler = new RecordingHandler();
+    private boolean originalUseParentHandlers;
+    private Level originalLevel;
+
+    @BeforeEach
+    void attachHandler() {
+        originalUseParentHandlers = julLogger.getUseParentHandlers();
+        originalLevel = julLogger.getLevel();
+        julLogger.setUseParentHandlers(false);
+        julLogger.setLevel(Level.ALL);
+        handler.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+    }
+
+    @AfterEach
+    void detachHandler() {
+        julLogger.removeHandler(handler);
+        julLogger.setLevel(originalLevel);
+        julLogger.setUseParentHandlers(originalUseParentHandlers);
+    }
+
+    @Test
+    void debug_doesNotLogWhenDebuggingIsDisabled() {
+        new TowerLogger().debug("hidden");
+
+        assertThat(handler.record, nullValue());
+    }
+
+    @Test
+    void debug_usesFineLevelAndJenkinsCompatibleLoggerWhenEnabled() {
+        TowerLogger towerLogger = new TowerLogger();
+        towerLogger.setDebugging(true);
+
+        towerLogger.debug("request completed");
+
+        assertThat(handler.record.getLoggerName(), is(TowerLogger.class.getName()));
+        assertThat(handler.record.getLevel(), is(Level.FINE));
+        assertThat(handler.record.getMessage(), is("{0}{1}"));
+        assertThat(handler.record.getParameters(), is(new Object[] {"[Ansible-Tower] ", "request completed"}));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void logMessage_keepsCompatibilityByDelegatingToDebug() {
+        TowerLogger towerLogger = new TowerLogger();
+        towerLogger.setDebugging(true);
+
+        towerLogger.logMessage("legacy diagnostic");
+
+        assertThat(handler.record.getLevel(), is(Level.FINE));
+    }
+
+    @Test
+    void warning_logsWhenDebuggingIsDisabled() {
+        new TowerLogger().warning("gateway failure");
+
+        assertThat(handler.record.getLevel(), is(Level.WARNING));
+    }
+
+    @Test
+    void severe_logsWhenDebuggingIsDisabled() {
+        new TowerLogger().severe("retries exhausted");
+
+        assertThat(handler.record.getLevel(), is(Level.SEVERE));
+    }
+
+    @Test
+    void writeMessage_logsWithoutDebugFlag() {
+        TowerLogger.writeMessage("connection test");
+
+        assertThat(handler.record.getLevel(), is(Level.INFO));
+    }
+
+    private static class RecordingHandler extends Handler {
+        private LogRecord record;
+
+        @Override
+        public void publish(LogRecord record) {
+            this.record = record;
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Improve Ansible Tower plugin diagnostics and make synchronous workflow polling resilient to temporary AAP controller and gateway failures.

This change:

- Adds `FINE`, `INFO`, `WARNING`, and `SEVERE` logging levels.
- Keeps `Enable Debugging` as the gate for detailed `FINE` diagnostics.
- Always records operational warnings and severe failures.
- Standardizes retry logs with job ID, template type, endpoint, HTTP status, attempt, and delay.
- Records exhausted retries at `SEVERE`.
- Removes full payloads, credentials, authorization headers, and token identifiers from diagnostic logs.
- Keeps the deprecated `logMessage()` method for compatibility.
- Separates status polling from best-effort log import so unavailable event endpoints do not change a successful AAP job result.
- Polls job status every five seconds and workflow output every ten seconds with independent transient backoff.
- Adds `LOG_IMPORT_RESULT` with `SKIPPED`, `DEFERRED`, `SUCCESS`, and `PARTIAL` states while preserving existing result keys.
- Uses the completed status response for both `completed` and `failed`, avoiding a redundant final status request.
- Tracks processed workflow node IDs, continues past running parallel nodes, and follows pagination without duplicating child output.
- Retries final log import immediately, after two seconds, and after five seconds.
- Applies 10-second connect and connection-request timeouts and a 30-second read timeout.
- Treats HTTP 502, 503, 504, transport timeouts, refused/reset connections, and empty responses as transient where appropriate.
- Updates the Jenkins help text and rewrites the README for current Tower, AWX, and AAP 2.5+ behavior.

### Testing done

Added automated tests covering debug logging, JUL logger namespace and levels, logging while debugging is disabled, compatibility of `logMessage()`, retry metadata, independent status/log polling, transient recovery and exhaustion, partial log import, disabled log import, AAP job failures, workflow node pagination and deduplication, request budgets, HTTP timeout configuration, and transient transport classification.

Executed `mvn test`:

```text
Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Executed `mvn verify`:

```text
BUILD SUCCESS
```

Also executed `git diff --check` and verified that production sources no longer contain direct `System.out` or `System.err` logging.

Performed a live smoke test from Jenkins against AAP Controller 4.7.12 using workflow template 8 with two child job templates. The workflow and both child jobs completed successfully, child output was imported once without duplication, and the Pipeline returned:

```text
JOB_RESULT=SUCCESS
LOG_IMPORT_RESULT=SUCCESS
```

The Jenkins Log Recorder confirmed status polling at approximately five-second intervals, workflow log polling at approximately ten-second intervals, final log import after completion, and successful OAuth token cleanup. No live 502/503/504 response occurred during the smoke test; transient and exhausted paths are covered with deterministic fake-clock/API tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
