### PR TITLE
Build: address PR #39 and #42 review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The Ansible Tower Plugin connects Jenkins to Ansible Tower, AWX, and Red Hat Ans
 
 ## Requirements
 
-- Jenkins 2.479.1 or newer.
-- Java 21 or newer.
+- Jenkins 2.504.3 or newer. Compatibility is also verified against the Jenkins 2.554 weekly release.
+- Java 17 or newer at runtime, as derived from the Jenkins 2.504.3 baseline.
+- JDK 21 and Maven 3.9.6 or newer to build the plugin locally. Jenkins CI and the official Maven CD workflow also use JDK 21.
 - A reachable Tower, AWX, or AAP controller API.
 - A Jenkins credential with sufficient controller permissions.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ The Ansible Tower Plugin connects Jenkins to Ansible Tower, AWX, and Red Hat Ans
 
 For local development, use JDK 21 and Maven 3.9.6 or newer.
 
+### Java 17 compatibility verification
+
+The minimum Jenkins baseline, Jenkins 2.504.3, has been verified with OpenJDK 17. The plugin classes built by JDK 21 use Java 17 bytecode (class-file major version 61), and the generated HPI declares `Java-Version: 17`.
+
+To verify the minimum runtime locally, point `JAVA_HOME` and `PATH` to a JDK 17 installation and run the standard build without skipping tests:
+
+```bash
+JAVA_HOME=/path/to/jdk-17 \
+PATH=/path/to/jdk-17/bin:$PATH \
+mvn -ntp clean verify
+```
+
+This verification starts Jenkins 2.504.3 under the Jenkins Test Harness and checks plugin loading, Apache HttpClient API plugin class loading, descriptor registration, configuration round trips, data-bound fields, and the existing HTTP behavior tests. A successful run must complete without `UnsupportedClassVersionError`, `ClassNotFoundException`, `NoClassDefFoundError`, or other linkage errors.
+
 ## Installation
 
 1. Open **Manage Jenkins → Plugins**.

--- a/README.md
+++ b/README.md
@@ -23,20 +23,6 @@ The Ansible Tower Plugin connects Jenkins to Ansible Tower, AWX, and Red Hat Ans
 
 For local development, use JDK 21 and Maven 3.9.6 or newer.
 
-### Java 17 compatibility verification
-
-The minimum Jenkins baseline, Jenkins 2.504.3, has been verified with OpenJDK 17. The plugin classes built by JDK 21 use Java 17 bytecode (class-file major version 61), and the generated HPI declares `Java-Version: 17`.
-
-To verify the minimum runtime locally, point `JAVA_HOME` and `PATH` to a JDK 17 installation and run the standard build without skipping tests:
-
-```bash
-JAVA_HOME=/path/to/jdk-17 \
-PATH=/path/to/jdk-17/bin:$PATH \
-mvn -ntp clean verify
-```
-
-This verification starts Jenkins 2.504.3 under the Jenkins Test Harness and checks plugin loading, Apache HttpClient API plugin class loading, descriptor registration, configuration round trips, data-bound fields, and the existing HTTP behavior tests. A successful run must complete without `UnsupportedClassVersionError`, `ClassNotFoundException`, `NoClassDefFoundError`, or other linkage errors.
-
 ## Installation
 
 1. Open **Manage Jenkins → Plugins**.

--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,6 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <id>john-westcott-iv</id>
-            <name>John Westcott IV</name>
-            <email>john.westcott.iv@redhat.com</email>
-        </developer>
-    </developers>
-
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/ansible-tower-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/ansible-tower-plugin.git</developerConnection>
@@ -40,11 +32,13 @@
     </scm>
 
     <properties>
-        <revision>0.18.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jenkins.version>2.504.3</jenkins.version>
         <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+        <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+        <ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
+        <banObsoleteDependencyOverrides.skip>false</banObsoleteDependencyOverrides.skip>
     </properties>
 
     <repositories>
@@ -96,14 +90,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject</artifactId>
-            <version>2.1.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <!-- This API plugin is not managed by the current Jenkins BOM. -->
-            <version>4.5.14-269.vfa_2321039a_83</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.504.3</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>
@@ -59,7 +60,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.504.x</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>5983.v443959746f1f</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
         <revision>0.18.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jenkins.version>2.479.1</jenkins.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <jenkins.version>2.504.3</jenkins.version>
+        <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     </properties>
 
     <repositories>
@@ -61,31 +61,12 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>21</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <disabledTestInjection>true</disabledTestInjection>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.479.x</artifactId>
-                <version>3482.vc10d4f6da_28a_</version>
+                <artifactId>bom-2.504.x</artifactId>
+                <version>5983.v443959746f1f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -118,17 +99,11 @@
             <version>2.1.3</version>
             <optional>true</optional>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.22.0</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <!-- This API plugin is not managed by the current Jenkins BOM. -->
+            <version>4.5.14-269.vfa_2321039a_83</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerGlobalConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerGlobalConfig.java
@@ -10,7 +10,7 @@ import hudson.util.XStream2;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class AnsibleTowerGlobalConfig extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json)
+    public boolean configure(StaplerRequest2 req, JSONObject json)
             throws FormException
     {
         req.bindJSON(this, json);
@@ -67,4 +67,3 @@ public class AnsibleTowerGlobalConfig extends GlobalConfiguration {
     }
 
 }
-

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerInstallation.java
@@ -21,7 +21,6 @@ import hudson.model.Descriptor;
 import hudson.model.Project;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -103,7 +102,7 @@ public class TowerInstallation extends AbstractDescribableImpl<TowerInstallation
         String username = null;
         String password = null;
         String oauth_token = null;
-        if (StringUtils.isNotBlank(towerCredentialsId)) {
+        if (towerCredentialsId != null && !towerCredentialsId.trim().isEmpty()) {
             List<StandardUsernamePasswordCredentials> credsList = getCredsList(StandardUsernamePasswordCredentials.class, run);
             for (StandardUsernamePasswordCredentials creds : credsList) {
                 if (creds.getId().equals(towerCredentialsId)) {

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
@@ -12,17 +12,15 @@ import org.apache.http.client.HttpClient;
 import org.jenkinsci.plugins.ansible_tower.util.TowerConnector;
 import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class PluginCompatibilityTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
-
     @Test
-    public void pluginLoadsDescriptorsAndHttpClientFromApiPlugin() throws Exception {
+    public void pluginLoadsDescriptorsAndHttpClientFromApiPlugin(JenkinsRule jenkinsRule) throws Exception {
         assertThat(jenkinsRule.jenkins.getPluginManager().getPlugin("ansible-tower"), notNullValue());
         assertThat(jenkinsRule.jenkins.getPluginManager().getPlugin("apache-httpcomponents-client-4-api"), notNullValue());
         assertThat(Jenkins.get().getDescriptor(AnsibleTower.class), instanceOf(AnsibleTower.DescriptorImpl.class));
@@ -42,7 +40,7 @@ public class PluginCompatibilityTest {
     }
 
     @Test
-    public void pipelineStepsRetainDataBoundValues() {
+    public void pipelineStepsRetainDataBoundValues(JenkinsRule jenkinsRule) {
         AnsibleTowerStep job = new AnsibleTowerStep("tower", "credential", "template", "check");
         job.setExtraVars("{\"key\":\"value\"}");
         job.setTowerLogLevel("full");
@@ -69,7 +67,7 @@ public class PluginCompatibilityTest {
     }
 
     @Test
-    public void freestyleConfigurationAndGlobalInstallationRoundTrip() throws Exception {
+    public void freestyleConfigurationAndGlobalInstallationRoundTrip(JenkinsRule jenkinsRule) throws Exception {
         TowerInstallation installation = new TowerInstallation(
                 "tower", "https://tower.example.com", "/api/controller/v2", "credential", true, true);
         AnsibleTowerGlobalConfig.get().setTowerInstallation(List.of(installation));

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
@@ -1,0 +1,108 @@
+package org.jenkinsci.plugins.ansible_tower;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import hudson.model.FreeStyleProject;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.apache.http.client.HttpClient;
+import org.jenkinsci.plugins.ansible_tower.util.TowerConnector;
+import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class PluginCompatibilityTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void pluginLoadsDescriptorsAndHttpClientFromApiPlugin() throws Exception {
+        assertThat(jenkinsRule.jenkins.getPluginManager().getPlugin("ansible-tower"), notNullValue());
+        assertThat(jenkinsRule.jenkins.getPluginManager().getPlugin("apache-httpcomponents-client-4-api"), notNullValue());
+        assertThat(Jenkins.get().getDescriptor(AnsibleTower.class), instanceOf(AnsibleTower.DescriptorImpl.class));
+        assertThat(Jenkins.get().getDescriptor(AnsibleTowerProjectSyncFreestyle.class),
+                instanceOf(AnsibleTowerProjectSyncFreestyle.DescriptorImpl.class));
+        assertThat(Jenkins.get().getDescriptor(AnsibleTowerProjectRevisionFreestyle.class),
+                instanceOf(AnsibleTowerProjectRevisionFreestyle.DescriptorImpl.class));
+        assertStep("ansibleTower", AnsibleTowerStep.DescriptorImpl.class);
+        assertStep("ansibleTowerProjectSync", AnsibleTowerProjectSyncStep.DescriptorImpl.class);
+        assertStep("ansibleTowerProjectRevision", AnsibleTowerProjectRevisionStep.DescriptorImpl.class);
+
+        Class<?> httpClient = Jenkins.get().getPluginManager().uberClassLoader.loadClass(HttpClient.class.getName());
+        Class<?> apiPluginHttpClient = Jenkins.get().getPluginManager()
+                .getPlugin("apache-httpcomponents-client-4-api").classLoader.loadClass(HttpClient.class.getName());
+        assertThat(apiPluginHttpClient, is(httpClient));
+        assertThat(TowerConnector.class.getClassLoader().loadClass(HttpClient.class.getName()), is(httpClient));
+    }
+
+    @Test
+    public void pipelineStepsRetainDataBoundValues() {
+        AnsibleTowerStep job = new AnsibleTowerStep("tower", "credential", "template", "check");
+        job.setExtraVars("{\"key\":\"value\"}");
+        job.setTowerLogLevel("full");
+        job.setAsync(true);
+        assertThat(job.getTowerServer(), is("tower"));
+        assertThat(job.getTowerCredentialsId(), is("credential"));
+        assertThat(job.getJobTemplate(), is("template"));
+        assertThat(job.getJobType(), is("check"));
+        assertThat(job.getExtraVars(), is("{\"key\":\"value\"}"));
+        assertThat(job.getTowerLogLevel(), is("full"));
+        assertThat(job.getAsync(), is(true));
+
+        AnsibleTowerProjectSyncStep sync = new AnsibleTowerProjectSyncStep(
+                "tower", "credential", "project", false, false, false, true, true);
+        assertThat(sync.getProject(), is("project"));
+        assertThat(sync.getThrowExceptionWhenFail(), is(true));
+        assertThat(sync.getAsync(), is(true));
+
+        AnsibleTowerProjectRevisionStep revision = new AnsibleTowerProjectRevisionStep(
+                "tower", "credential", "project", "main", true, false);
+        assertThat(revision.getRevision(), is("main"));
+        assertThat(revision.getVerbose(), is(true));
+        assertThat(revision.getThrowExceptionWhenFail(), is(false));
+    }
+
+    @Test
+    public void freestyleConfigurationAndGlobalInstallationRoundTrip() throws Exception {
+        TowerInstallation installation = new TowerInstallation(
+                "tower", "https://tower.example.com", "/api/controller/v2", "credential", true, true);
+        AnsibleTowerGlobalConfig.get().setTowerInstallation(List.of(installation));
+        AnsibleTowerGlobalConfig.get().save();
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+        project.getBuildersList().add(new AnsibleTowerProjectSyncFreestyle(
+                "tower", "credential", "project", true, true, false));
+        project = jenkinsRule.configRoundtrip(project);
+        AnsibleTowerProjectSyncFreestyle restored = project.getBuildersList()
+                .get(AnsibleTowerProjectSyncFreestyle.class);
+        assertThat(restored.getTowerServer(), is("tower"));
+        assertThat(restored.getTowerCredentialsId(), is("credential"));
+        assertThat(restored.getProject(), is("project"));
+        assertThat(restored.getVerbose(), is(true));
+        assertThat(restored.getImportTowerLogs(), is(true));
+        assertThat(restored.getRemoveColor(), is(false));
+
+        String xml = Jenkins.XSTREAM2.toXML(installation);
+        TowerInstallation restoredInstallation = (TowerInstallation) Jenkins.XSTREAM2.fromXML(xml);
+        assertThat(restoredInstallation.getTowerDisplayName(), is("tower"));
+        assertThat(restoredInstallation.getTowerURL(), is("https://tower.example.com"));
+        assertThat(restoredInstallation.getTowerApiBasePath(), is("/api/controller/v2"));
+        assertThat(restoredInstallation.getTowerCredentialsId(), is("credential"));
+        assertThat(restoredInstallation.getTowerTrustCert(), is(true));
+        assertThat(restoredInstallation.getEnableDebugging(), is(true));
+    }
+
+    private static void assertStep(String functionName, Class<? extends StepDescriptor> type) {
+        StepDescriptor descriptor = Jenkins.get().getExtensionList(StepDescriptor.class).stream()
+                .filter(candidate -> functionName.equals(candidate.getFunctionName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(descriptor, instanceOf(type));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up remediation for the reviewer feedback on #39 and #42. This keeps JDK 21 for CI/CD while allowing the Jenkins plugin parent and HPI plugin to derive the runtime bytecode level from the selected Jenkins baseline.

## Reviewer feedback checklist

- [x] Manual Java release and custom compiler configuration removed
- [x] Jenkins baseline aligned to supported historical LTS 2.504.3
- [x] Latest matching `bom-2.504.x:5983.v443959746f1f` imported
- [x] Direct Apache HttpClient replaced with `apache-httpcomponents-client-4-api`
- [x] Commons Codec direct dependency removed
- [x] Injected tests enabled and passing
- [x] Plugin-first classloader configuration removed
- [x] Minimum-baseline `mvn -ntp clean verify` passed on JDK 21 (66 tests, including injected tests)
- [x] Jenkins 2.554 compatibility `mvn -ntp -Djenkins.version=2.554 clean verify` passed on JDK 21
- [x] Generated HPI inspected: Jenkins-Version 2.504.3, Java-Version 17, HttpClient API dependency declared
- [x] HPI contains no private HttpClient, HttpCore, or Commons Codec JARs

## Compatibility evidence

The baseline build derives compiler release 17 and produces class-file major version 61. The Jenkins 2.554 compatibility build derives Java 21 and starts the Jenkins Test Harness without linkage or classloading errors. Regression tests verify plugin loading, descriptor discovery, data binding, configuration round trips, and HttpClient API plugin class loading. Existing mock HTTP server tests continue to pass without contacting a real Tower/AWX/AAP instance.

The current 2.504.x BOM manages both `envinject` and `apache-httpcomponents-client-4-api`; their explicit versions were removed and the obsolete-dependency override check confirms BOM management.

## Java 17 minimum-runtime evidence

The minimum baseline was verified with OpenJDK 17.0.19, not only by inspecting bytecode. The plugin was first built by JDK 21 with the parent-derived Java 17 target; that existing output was then exercised with Maven and Jenkins Test Harness running on JDK 17:

```bash
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.19.0.10-2.el9.alma.1.x86_64 \
PATH=/usr/lib/jvm/java-17-openjdk-17.0.19.0.10-2.el9.alma.1.x86_64/bin:$PATH \
mvn -ntp -Dtest=PluginCompatibilityTest test
```

Maven reported that the production classes were already up to date, so this exercised the JDK-21-built, Java-17-targeted classes. Jenkins Test Harness started Jenkins 2.504.3, completed initialization, loaded the Ansible Tower and Apache HttpClient API plugins, registered the Freestyle and Pipeline descriptors, and passed all three compatibility regression tests without `UnsupportedClassVersionError`, `ClassNotFoundException`, `NoClassDefFoundError`, or linkage errors.

A separate complete acceptance build was also run entirely on JDK 17:

```bash
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-17.0.19.0.10-2.el9.alma.1.x86_64 \
PATH=/usr/lib/jvm/java-17-openjdk-17.0.19.0.10-2.el9.alma.1.x86_64/bin:$PATH \
mvn -ntp clean verify
```

Result: 66 tests, 0 failures, 0 errors, 1 standard injected-test skip, and `BUILD SUCCESS`. The baseline HPI declares `Java-Version: 17`, and `javap -verbose` reports class-file major version 61. CI and Maven CD remain configured to build with JDK 21.


## Follow-up review cleanup

The latest review feedback is addressed in `2a4eec7`:

- removed the obsolete `<developers>` section (plugin metadata comes from repository-permissions-updater)
- removed unused `revision` and explicit UTF-8 encoding properties
- enabled JUnit 4 import, deprecated Stapler, Commons Lang 2, and obsolete dependency override checks
- removed explicit `envinject` and Apache HttpClient API plugin versions; BOM resolves them to `2.926.v69c9b_3896a_96` and `4.5.14-269.vfa_2321039a_83`
- migrated the compatibility regression test to JUnit 5 `@WithJenkins`
- replaced Commons Lang 2 usage with the Java standard library
- migrated global configuration binding from `StaplerRequest` to `StaplerRequest2`

All four newly enabled checks pass on the baseline JDK 21 build, the full JDK 17 minimum-runtime build, and the Jenkins 2.554 compatibility build.
