### PR TITLE
Improve build console diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,36 @@ To collect detailed diagnostics:
 2. Open **Manage Jenkins → System Log**.
 3. Add a Log Recorder for `org.jenkinsci.plugins.ansible_tower` at `FINE` or `ALL`.
 
-Operational `WARNING` and `SEVERE` records are emitted even when debugging is disabled. Messages retain the `[Ansible-Tower]` prefix. System diagnostics do not log request/response payloads, credentials, authorization headers, or tokens. The separate `verbose` build-console option may print expanded launch values.
+Logging is split between two audiences. The build console always shows user-facing
+milestones, retry notices, and failures needed to diagnose the current run. Jenkins
+System Log keeps lower-level diagnostics; successful HTTP request metadata is
+available at `FINE`, while operational `WARNING` and `SEVERE` records are emitted
+even when debugging is disabled. Messages retain the `[Ansible-Tower]` prefix.
+
+Neither destination logs request or response payloads, extra variables, credentials,
+authorization headers, passwords, or tokens. Endpoint query values are redacted.
+The `verbose` build-console option adds safe expansion and launch progress details,
+but does not expose expanded extra variables or credential values.
+
+Typical build-console diagnostics look like:
+
+```text
+[Ansible-Tower] INFO: Resolving job template: template=deploy
+[Ansible-Tower] ERROR: HTTP request completed: method=GET, endpoint=/api/controller/v2/job_templates/?name=<redacted>, httpStatus=502, durationMs=103
+[Ansible-Tower] ERROR: Unable to lookup job template; the job was not launched: Unexpected error code returned when getting template (502)
+```
+
+If a launch request receives a transient gateway response or loses its connection,
+the console explicitly reports that the launch outcome is unknown. The plugin does
+not automatically retry that POST because the controller may already have created
+the job:
+
+```text
+[Ansible-Tower] WARNING: Tower launch outcome is unknown; the controller may have created the job, but Jenkins received HTTP 502. Automatic retry was not performed.
+```
+
+Polling recovery continues to report both the retry and recovery in the build
+console, including the job ID, endpoint, status, attempt, and retry delay.
 
 For Jenkins installed as a Linux systemd service:
 

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ Typical build-console diagnostics look like:
 
 ```text
 [Ansible-Tower] INFO: Resolving job template: template=deploy
-[Ansible-Tower] ERROR: HTTP request completed: method=GET, endpoint=/api/controller/v2/job_templates/?name=<redacted>, httpStatus=502, durationMs=103
-[Ansible-Tower] ERROR: Unable to lookup job template; the job was not launched: Unexpected error code returned when getting template (502)
+[Ansible-Tower] ERROR: HTTP request completed: method=GET, url=https://aap.example.com/api/controller/v2/job_templates/?name=<redacted>, httpStatus=502, durationMs=103
+[Ansible-Tower] ERROR: Unable to lookup job template; the job was not launched: GET https://aap.example.com/api/controller/v2/job_templates/?name=<redacted> returned HTTP 502
 ```
 
 If a launch request receives a transient gateway response or loses its connection,

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Typical build-console diagnostics look like:
 ```text
 [Ansible-Tower] INFO: Resolving job template: template=deploy
 [Ansible-Tower] ERROR: HTTP request failed: method=GET, url=https://aap.example.com/api/controller/v2/job_templates/?name=<redacted>, httpStatus=502, durationMs=103
-[Ansible-Tower] ERROR: Job was not launched because the job template lookup request failed
+[Ansible-Tower] ERROR: Job was not launched because the job template lookup failed
 ```
 
 If a launch request receives a transient gateway response or loses its connection,

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ Typical build-console diagnostics look like:
 
 ```text
 [Ansible-Tower] INFO: Resolving job template: template=deploy
-[Ansible-Tower] ERROR: HTTP request completed: method=GET, url=https://aap.example.com/api/controller/v2/job_templates/?name=<redacted>, httpStatus=502, durationMs=103
-[Ansible-Tower] ERROR: Unable to lookup job template; the job was not launched: GET https://aap.example.com/api/controller/v2/job_templates/?name=<redacted> returned HTTP 502
+[Ansible-Tower] ERROR: HTTP request failed: method=GET, url=https://aap.example.com/api/controller/v2/job_templates/?name=<redacted>, httpStatus=502, durationMs=103
+[Ansible-Tower] ERROR: Job was not launched because the job template lookup request failed
 ```
 
 If a launch request receives a transient gateway response or loses its connection,

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectRevisionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectRevisionStep.java
@@ -14,6 +14,7 @@ import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.ansible_tower.util.GetUserPageCredentials;
 import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation;
+import org.jenkinsci.plugins.ansible_tower.util.TowerLogger;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
@@ -155,14 +156,20 @@ public class AnsibleTowerProjectRevisionStep extends AbstractStepImpl {
             boolean throwExceptionWhenFail = true;
             if(step.getThrowExceptionWhenFail() != null) { throwExceptionWhenFail = step.getThrowExceptionWhenFail(); }
             Properties map = new Properties();
-            boolean runResult = runner.projectRevision(
-                    listener.getLogger(), step.getTowerServer(), step.getTowerCredentialsId(),
-                    project, revision,
-                    verbose,
-                    envVars, ws, run, map
-            );
+            boolean runResult;
+            try {
+                runResult = runner.projectRevision(
+                        listener.getLogger(), step.getTowerServer(), step.getTowerCredentialsId(),
+                        project, revision,
+                        verbose,
+                        envVars, ws, run, map
+                );
+            } catch(RuntimeException failure) {
+                throw new AbortException(TowerLogger.reportUnexpected(
+                    listener.getLogger(), "Ansible Tower project revision operation", failure));
+            }
             if(!runResult && throwExceptionWhenFail) {
-                throw new AbortException("Ansible Tower Project Revision build step failed");
+                throw new AbortException(runner.getLastFailureMessage());
             }
             return map;
         }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectRevisionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectRevisionStep.java
@@ -166,7 +166,7 @@ public class AnsibleTowerProjectRevisionStep extends AbstractStepImpl {
                 );
             } catch(RuntimeException failure) {
                 throw new AbortException(TowerLogger.reportUnexpected(
-                    listener.getLogger(), "Ansible Tower project revision operation", failure));
+                    "Ansible Tower project revision operation", failure));
             }
             if(!runResult && throwExceptionWhenFail) {
                 throw new AbortException(runner.getLastFailureMessage());

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectSyncStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectSyncStep.java
@@ -191,7 +191,7 @@ public class AnsibleTowerProjectSyncStep extends AbstractStepImpl {
                 );
             } catch(RuntimeException failure) {
                 throw new AbortException(TowerLogger.reportUnexpected(
-                    listener.getLogger(), "Ansible Tower project sync operation", failure));
+                    "Ansible Tower project sync operation", failure));
             }
             if(!runResult && throwExceptionWhenFail) {
                 throw new AbortException(runner.getLastFailureMessage());

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectSyncStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerProjectSyncStep.java
@@ -11,6 +11,7 @@ import hudson.model.*;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.ansible_tower.util.GetUserPageCredentials;
 import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation;
+import org.jenkinsci.plugins.ansible_tower.util.TowerLogger;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
@@ -182,12 +183,18 @@ public class AnsibleTowerProjectSyncStep extends AbstractStepImpl {
             boolean async = false;
             if(step.getAsync() != null) { async = step.getAsync(); }
             Properties map = new Properties();
-            boolean runResult = runner.projectSync(
-                    listener.getLogger(), step.getTowerServer(), step.getTowerCredentialsId(), project, verbose,
-                    importTowerLogs, removeColor, envVars, ws, run, map, async
-            );
+            boolean runResult;
+            try {
+                runResult = runner.projectSync(
+                        listener.getLogger(), step.getTowerServer(), step.getTowerCredentialsId(), project, verbose,
+                        importTowerLogs, removeColor, envVars, ws, run, map, async
+                );
+            } catch(RuntimeException failure) {
+                throw new AbortException(TowerLogger.reportUnexpected(
+                    listener.getLogger(), "Ansible Tower project sync operation", failure));
+            }
             if(!runResult && throwExceptionWhenFail) {
-                throw new AbortException("Ansible Tower Project Sync build step failed");
+                throw new AbortException(runner.getLastFailureMessage());
             }
             return map;
         }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -53,10 +53,6 @@ public class AnsibleTowerRunner {
     ) {
         milestone(logger, "Starting job template operation: server=" + towerServer
             + ", template=" + jobTemplate + ", templateType=" + templateType);
-        if (verbose) {
-            logger.println("Beginning Ansible Tower Run on " + towerServer);
-        }
-
         AnsibleTowerGlobalConfig myConfig = new AnsibleTowerGlobalConfig();
         TowerInstallation towerConfigToRunOn = myConfig.getTowerInstallationByName(towerServer);
         if (towerConfigToRunOn == null) {
@@ -346,10 +342,6 @@ public class AnsibleTowerRunner {
                                FilePath ws, Run<?, ?> run, Properties towerResults, boolean async) {
 
         milestone(logger, "Starting project sync: server=" + towerServer + ", project=" + projectName);
-        if (verbose) {
-            logger.println("Beginning Ansible Tower Project Sync on " + towerServer + " for " + projectName);
-        }
-
         // Get our Tower connector
         AnsibleTowerGlobalConfig myConfig = new AnsibleTowerGlobalConfig();
         TowerInstallation towerConfigToRunOn = myConfig.getTowerInstallationByName(towerServer);
@@ -506,10 +498,6 @@ public class AnsibleTowerRunner {
                                    EnvVars envVars, FilePath ws, Run<?, ?> run, Properties towerResults) {
 
         milestone(logger, "Starting project revision: server=" + towerServer + ", project=" + projectName);
-        if (verbose) {
-            logger.println("Beginning Ansible Tower Project Revision on " + towerServer + " for " + projectName);
-        }
-
         // Get our Tower connector
         AnsibleTowerGlobalConfig myConfig = new AnsibleTowerGlobalConfig();
         TowerInstallation towerConfigToRunOn = myConfig.getTowerInstallationByName(towerServer);

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -12,8 +12,7 @@ import hudson.model.Run;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
-import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRequestException;
-import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerTransientException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.ConsoleDiagnosedException;
 import org.jenkinsci.plugins.ansible_tower.util.*;
 import org.jenkinsci.plugins.envinject.service.EnvInjectActionSetter;
 
@@ -29,6 +28,22 @@ public class AnsibleTowerRunner {
     private boolean fail(PrintStream console, String message) {
         lastFailureMessage = TowerLogger.sanitizeMessage(message);
         console.println("[Ansible-Tower] ERROR: " + lastFailureMessage);
+        return false;
+    }
+
+    private boolean failOperation(PrintStream console, String outcome, AnsibleTowerException failure) {
+        String message = hasConsoleDiagnostics(failure)
+            ? outcome
+            : outcome + ": " + failure.getMessage();
+        return fail(console, message);
+    }
+
+    static boolean hasConsoleDiagnostics(Throwable failure) {
+        Throwable current = failure;
+        while(current != null) {
+            if(current instanceof ConsoleDiagnosedException) { return true; }
+            current = current.getCause();
+        }
         return false;
     }
 
@@ -165,11 +180,8 @@ public class AnsibleTowerRunner {
             template = myTowerConnection.getJobTemplate(expandedJobTemplate, templateType);
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            if(e instanceof AnsibleTowerRequestException || e instanceof AnsibleTowerTransientException) {
-                return fail(logger, "Job was not launched because the " + templateType
-                    + " template lookup request failed");
-            }
-            return fail(logger, "Unable to lookup job template; the job was not launched: " + e.getMessage());
+            return failOperation(logger, "Job was not launched because the " + templateType
+                + " template lookup failed", e);
         }
         milestone(logger, "Job template resolved: templateId=" + template.getLong("id"));
 
@@ -223,7 +235,7 @@ public class AnsibleTowerRunner {
             this.myJob.setJobId(myTowerConnection.submitTemplate(template.getLong("id"), expandedExtraVars, expandedLimit, expandedJobTags, expandedSkipJobTags, jobType, expandedInventory, expandedCredential, expandedScmBranch, templateType));
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Unable to confirm job launch: " + e.getMessage());
+            return failOperation(logger, "Unable to confirm job launch", e);
         }
 
         String jobURL = myTowerConnection.getJobURL(this.myJob.getJobID(), templateType);
@@ -254,7 +266,7 @@ public class AnsibleTowerRunner {
             return result;
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Failed to poll job status from Tower: " + e.getMessage());
+            return failOperation(logger, "Failed to poll job status from Tower", e);
         }
 
         boolean wasSuccessful = pollingResult.isSuccessful();
@@ -265,7 +277,7 @@ public class AnsibleTowerRunner {
             jenkinsVariables = this.myJob.getExports();
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Failed to get exported variables: " + e.getMessage());
+            return failOperation(logger, "Failed to get exported variables", e);
         }
         for (Map.Entry<String, String> entrySet : jenkinsVariables.entrySet()) {
             if (verbose) {
@@ -381,7 +393,7 @@ public class AnsibleTowerRunner {
             myProject = new TowerProject(expandedProject, myTowerConnection);
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Unable to lookup project; project sync was not launched: " + e.getMessage());
+            return failOperation(logger, "Project sync was not launched because project lookup failed", e);
         }
         milestone(logger, "Project resolved: project=" + expandedProject);
 
@@ -393,7 +405,7 @@ public class AnsibleTowerRunner {
             }
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Failed to check whether the project can be synced: " + e.getMessage());
+            return failOperation(logger, "Failed to check whether the project can be synced", e);
         }
 
         if (verbose) {
@@ -407,7 +419,7 @@ public class AnsibleTowerRunner {
             projectSync = myProject.sync();
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Unable to confirm project sync launch: " + e.getMessage());
+            return failOperation(logger, "Unable to confirm project sync launch", e);
         }
 
         String syncURL = projectSync.getURL();
@@ -539,7 +551,7 @@ public class AnsibleTowerRunner {
             myProject = new TowerProject(expandedProject, myTowerConnection);
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Unable to lookup project; revision was not updated: " + e.getMessage());
+            return failOperation(logger, "Project revision was not updated because project lookup failed", e);
         }
         milestone(logger, "Project resolved: project=" + expandedProject);
 
@@ -555,7 +567,7 @@ public class AnsibleTowerRunner {
             return updated;
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
-            return fail(logger, "Unable to update project revision: " + e.getMessage());
+            return failOperation(logger, "Unable to update project revision", e);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -20,6 +20,19 @@ import java.util.*;
 
 public class AnsibleTowerRunner {
     private TowerJob myJob = null;
+    private String lastFailureMessage = "Ansible Tower operation failed";
+
+    public String getLastFailureMessage() { return lastFailureMessage; }
+
+    private boolean fail(PrintStream console, String message) {
+        lastFailureMessage = TowerLogger.sanitizeMessage(message);
+        console.println("[Ansible-Tower] ERROR: " + lastFailureMessage);
+        return false;
+    }
+
+    private void milestone(PrintStream console, String message) {
+        console.println("[Ansible-Tower] INFO: " + TowerLogger.sanitizeMessage(message));
+    }
 
     public boolean runJobTemplate(
             PrintStream logger, String towerServer, String towerCredentialsId, String jobTemplate, String jobType,
@@ -38,6 +51,8 @@ public class AnsibleTowerRunner {
             boolean verbose, String importTowerLogs, boolean removeColor, EnvVars envVars, String templateType,
             boolean importWorkflowChildLogs, FilePath ws, Run<?, ?> run, Properties towerResults, boolean async
     ) {
+        milestone(logger, "Starting job template operation: server=" + towerServer
+            + ", template=" + jobTemplate + ", templateType=" + templateType);
         if (verbose) {
             logger.println("Beginning Ansible Tower Run on " + towerServer);
         }
@@ -45,8 +60,7 @@ public class AnsibleTowerRunner {
         AnsibleTowerGlobalConfig myConfig = new AnsibleTowerGlobalConfig();
         TowerInstallation towerConfigToRunOn = myConfig.getTowerInstallationByName(towerServer);
         if (towerConfigToRunOn == null) {
-            logger.println("ERROR: Ansible tower server " + towerServer + " does not exist in Ansible Tower configuration");
-            return false;
+            return fail(logger, "Ansible Tower server " + towerServer + " does not exist in Jenkins configuration");
         }
 
         if (towerCredentialsId != null && !towerCredentialsId.equals("")) {
@@ -58,18 +72,17 @@ public class AnsibleTowerRunner {
         }
 
         TowerConnector myTowerConnection = towerConfigToRunOn.getTowerConnector();
+        myTowerConnection.setConsole(logger);
         this.myJob = new TowerJob(myTowerConnection);
         try {
             this.myJob.setTemplateType(templateType);
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: " + e);
-            return false;
+            return fail(logger, "Invalid template type: " + e.getMessage());
         }
 
         // Check the import logs settings
         if (!(importTowerLogs.matches("false") || importTowerLogs.matches("true") || importTowerLogs.matches("vars") || importTowerLogs.matches("full"))) {
-            logger.println("ERROR: Import Tower Logs must be one of (false, true, vars or full)");
-            return false;
+            return fail(logger, "Import Tower Logs must be one of false, true, vars, or full");
         }
 
         // If they came in empty then set them to null so that we don't pass a nothing through
@@ -113,7 +126,7 @@ public class AnsibleTowerRunner {
                 logger.println("Expanded job template to " + expandedJobTemplate);
             }
             if (expandedExtraVars != null && !expandedExtraVars.equals(extraVars)) {
-                logger.println("Expanded extra vars to " + expandedExtraVars);
+                logger.println("Expanded extra vars from the Jenkins environment");
             }
             if (expandedLimit != null && !expandedLimit.equals(limit)) {
                 logger.println("Expanded limit to " + expandedLimit);
@@ -128,7 +141,7 @@ public class AnsibleTowerRunner {
                 logger.println("Expanded inventory to " + expandedInventory);
             }
             if (expandedCredential != null && !expandedCredential.equals(credential)) {
-                logger.println("Expanded credentials to " + expandedCredential);
+                logger.println("Expanded launch credential reference from the Jenkins environment");
             }
             if (expandedScmBranch != null && !expandedScmBranch.equals(scmBranch)) {
                 logger.println("Expanded scmBranch to " + expandedScmBranch);
@@ -147,15 +160,16 @@ public class AnsibleTowerRunner {
             }
         }
 
+        milestone(logger, "Resolving job template: template=" + jobTemplate);
         // Get the job template.
         JSONObject template;
         try {
             template = myTowerConnection.getJobTemplate(expandedJobTemplate, templateType);
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Unable to lookup job template " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Unable to lookup job template; the job was not launched: " + e.getMessage());
         }
+        milestone(logger, "Job template resolved: templateId=" + template.getLong("id"));
 
 
         if (jobType != null && template.containsKey("ask_job_type_on_launch") && !template.getBoolean("ask_job_type_on_launch")) {
@@ -202,16 +216,17 @@ public class AnsibleTowerRunner {
             logger.println("Requesting tower to run " + templateType + " template " + expandedJobTemplate);
         }
 
+        milestone(logger, "Launching job template: templateId=" + template.getLong("id"));
         try {
             this.myJob.setJobId(myTowerConnection.submitTemplate(template.getLong("id"), expandedExtraVars, expandedLimit, expandedJobTags, expandedSkipJobTags, jobType, expandedInventory, expandedCredential, expandedScmBranch, templateType));
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Unable to request job template invocation " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Unable to confirm job launch: " + e.getMessage());
         }
 
         String jobURL = myTowerConnection.getJobURL(this.myJob.getJobID(), templateType);
-        logger.println("Template Job URL: " + jobURL);
+        milestone(logger, "Job accepted by controller: jobId=" + this.myJob.getJobID());
+        logger.println("[Ansible-Tower] Template Job URL: " + jobURL);
 
         towerResults.put("JOB_ID", Long.toString(this.myJob.getJobID()));
         towerResults.put("JOB_URL", jobURL);
@@ -236,9 +251,8 @@ public class AnsibleTowerRunner {
             Thread.currentThread().interrupt();
             return result;
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Failed to poll job status from Tower: " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Failed to poll job status from Tower: " + e.getMessage());
         }
 
         boolean wasSuccessful = pollingResult.isSuccessful();
@@ -248,13 +262,12 @@ public class AnsibleTowerRunner {
         try {
             jenkinsVariables = this.myJob.getExports();
         } catch (AnsibleTowerException e) {
-            logger.println("Failed to get exported variables: " + e);
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Failed to get exported variables: " + e.getMessage());
         }
         for (Map.Entry<String, String> entrySet : jenkinsVariables.entrySet()) {
             if (verbose) {
-                logger.println("Receiving from Jenkins job '" + entrySet.getKey() + "' with value '" + entrySet.getValue() + "'");
+                logger.println("Receiving exported variable '" + entrySet.getKey() + "' from Tower job");
             }
             envVars.put(entrySet.getKey(), entrySet.getValue());
             towerResults.put(entrySet.getKey(), entrySet.getValue());
@@ -266,9 +279,8 @@ public class AnsibleTowerRunner {
                 try {
                     envInjectActionSetter.addEnvVarsToRun(run, envVars);
                 } catch (Exception e) {
-                    logger.println("Unable to inject environment variables: " + e.getMessage());
                     myTowerConnection.releaseToken();
-                    return false;
+                    return fail(logger, "Unable to inject environment variables: " + e.getMessage());
                 }
             }
 
@@ -277,17 +289,16 @@ public class AnsibleTowerRunner {
                 try {
                     envInjectActionSetter.addEnvVarsToRun(run, envVars);
                 } catch (Exception e) {
-                    logger.println("Unable to inject environment variables: " + e.getMessage());
                     myTowerConnection.releaseToken();
-                    return false;
+                    return fail(logger, "Unable to inject environment variables: " + e.getMessage());
                 }
             }
         }
 
         if (wasSuccessful) {
-            logger.println("Tower completed the requested job");
+            milestone(logger, "Job completed: jobId=" + this.myJob.getJobID() + ", result=SUCCESS");
         } else {
-            logger.println("Tower failed to complete the requested job");
+            fail(logger, "Job completed: jobId=" + this.myJob.getJobID() + ", result=FAILED");
         }
 
         towerResults.put("JOB_RESULT", wasSuccessful ? "SUCCESS" : "FAILED");
@@ -311,31 +322,30 @@ public class AnsibleTowerRunner {
     }
 
     public boolean cancelJob(PrintStream logger) {
-        logger.println("Attempting to cancel launched Tower job");
+        milestone(logger, "Attempting to cancel launched Tower job");
         try {
             this.myJob.cancelJob();
-            logger.println("Job successfully canceled in Tower");
+            return fail(logger, "Tower job was canceled after the Jenkins operation was interrupted");
         } catch (AnsibleTowerException ae) {
-            logger.println("Failed to cancel tower job: " + ae);
+            return fail(logger, "Failed to cancel Tower job after interruption: " + ae.getMessage());
         }
-        return false;
     }
 
     public boolean cancelProjectSync(PrintStream logger, TowerProjectSync projectSync) {
-        logger.println("Attempting to cancel project sync");
+        milestone(logger, "Attempting to cancel project sync");
         try {
             projectSync.cancelSync();
-            logger.println("Project sync successfullt canceled in Tower");
+            return fail(logger, "Tower project sync was canceled after the Jenkins operation was interrupted");
         } catch (AnsibleTowerException ae) {
-            logger.println("Failed to cancel tower project sync: " + ae);
+            return fail(logger, "Failed to cancel Tower project sync after interruption: " + ae.getMessage());
         }
-        return false;
     }
 
     public boolean projectSync(PrintStream logger, String towerServer, String towerCredentialsId, String projectName,
                                boolean verbose, boolean importTowerLogs, boolean removeColor, EnvVars envVars,
                                FilePath ws, Run<?, ?> run, Properties towerResults, boolean async) {
 
+        milestone(logger, "Starting project sync: server=" + towerServer + ", project=" + projectName);
         if (verbose) {
             logger.println("Beginning Ansible Tower Project Sync on " + towerServer + " for " + projectName);
         }
@@ -344,8 +354,7 @@ public class AnsibleTowerRunner {
         AnsibleTowerGlobalConfig myConfig = new AnsibleTowerGlobalConfig();
         TowerInstallation towerConfigToRunOn = myConfig.getTowerInstallationByName(towerServer);
         if (towerConfigToRunOn == null) {
-            logger.println("ERROR: Ansible tower server " + towerServer + " does not exist in Ansible Tower configuration");
-            return false;
+            return fail(logger, "Ansible Tower server " + towerServer + " does not exist in Jenkins configuration");
         }
 
         // Apply credential override if provided
@@ -354,6 +363,7 @@ public class AnsibleTowerRunner {
         }
 
         TowerConnector myTowerConnection = towerConfigToRunOn.getTowerConnector();
+        myTowerConnection.setConsole(logger);
 
         myTowerConnection.setRemoveColor(removeColor);
 
@@ -367,26 +377,25 @@ public class AnsibleTowerRunner {
         }
 
         // Get the project
+        milestone(logger, "Resolving project: project=" + expandedProject);
         TowerProject myProject = null;
         try {
             myProject = new TowerProject(expandedProject, myTowerConnection);
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Unable to lookup project: " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Unable to lookup project; project sync was not launched: " + e.getMessage());
         }
+        milestone(logger, "Project resolved: project=" + expandedProject);
 
         // Make sure we can update the project
         try {
             if (!myProject.canUpdate()) {
-                logger.println("ERROR: The requested project can not be synced, is it a manual project?");
                 myTowerConnection.releaseToken();
-                return false;
+                return fail(logger, "The requested project cannot be synced; it may be a manual project");
             }
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Failed to check if the project can be synced: " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Failed to check whether the project can be synced: " + e.getMessage());
         }
 
         if (verbose) {
@@ -394,17 +403,18 @@ public class AnsibleTowerRunner {
         }
 
         // Request a project sync
+        milestone(logger, "Requesting project sync: project=" + expandedProject);
         TowerProjectSync projectSync;
         try {
             projectSync = myProject.sync();
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Unable to request project sync invocation " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Unable to confirm project sync launch: " + e.getMessage());
         }
 
         String syncURL = projectSync.getURL();
-        logger.println("Project Sync URL: " + syncURL);
+        milestone(logger, "Project sync accepted: syncId=" + projectSync.getID());
+        logger.println("[Ansible-Tower] Project Sync URL: " + syncURL);
         towerResults.put("SYNC_ID", projectSync.getID());
         towerResults.put("SYNC_URL", syncURL);
 
@@ -430,17 +440,15 @@ public class AnsibleTowerRunner {
                         logger.println(event);
                     }
                 } catch (AnsibleTowerException e) {
-                    logger.println("ERROR: Failed to get project sync events from tower: " + e.getMessage());
                     myTowerConnection.releaseToken();
-                    return false;
+                    return fail(logger, "Failed to get project sync events from Tower: " + e.getMessage());
                 }
             }
             try {
                 syncCompleted = projectSync.isComplete();
             } catch (AnsibleTowerException e) {
-                logger.println("ERROR: Failed to get project sync status from Tower: " + e.getMessage());
                 myTowerConnection.releaseToken();
-                return false;
+                return fail(logger, "Failed to get project sync status from Tower: " + e.getMessage());
             }
             if (!syncCompleted) {
                 if (Thread.currentThread().isInterrupted()) {
@@ -465,9 +473,8 @@ public class AnsibleTowerRunner {
                     logger.println(event);
                 }
             } catch (AnsibleTowerException e) {
-                logger.println("ERROR: Failed to get final project sync events from tower: " + e.getMessage());
                 myTowerConnection.releaseToken();
-                return false;
+                return fail(logger, "Failed to get final project sync events from Tower: " + e.getMessage());
             }
         }
 
@@ -475,18 +482,17 @@ public class AnsibleTowerRunner {
         try {
             wasSuccessful = projectSync.wasSuccessful();
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Failed to get project sync compltion status: " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Failed to get project sync completion status: " + e.getMessage());
         }
         towerResults.put("SYNC_RESULT", wasSuccessful ? "SUCCESS" : "FAILED");
 
         // Project sync can not export jenkins variables so we don't need to check for them here
 
         if (wasSuccessful) {
-            logger.println("Tower completed the requested project sync");
+            milestone(logger, "Project sync completed: syncId=" + projectSync.getID() + ", result=SUCCESS");
         } else {
-            logger.println("Tower failed to complete the requested project sync");
+            fail(logger, "Project sync completed: syncId=" + projectSync.getID() + ", result=FAILED");
         }
 
         myTowerConnection.releaseToken();
@@ -499,6 +505,7 @@ public class AnsibleTowerRunner {
                                    boolean verbose,
                                    EnvVars envVars, FilePath ws, Run<?, ?> run, Properties towerResults) {
 
+        milestone(logger, "Starting project revision: server=" + towerServer + ", project=" + projectName);
         if (verbose) {
             logger.println("Beginning Ansible Tower Project Revision on " + towerServer + " for " + projectName);
         }
@@ -507,8 +514,7 @@ public class AnsibleTowerRunner {
         AnsibleTowerGlobalConfig myConfig = new AnsibleTowerGlobalConfig();
         TowerInstallation towerConfigToRunOn = myConfig.getTowerInstallationByName(towerServer);
         if (towerConfigToRunOn == null) {
-            logger.println("ERROR: Ansible tower server " + towerServer + " does not exist in Ansible Tower configuration");
-            return false;
+            return fail(logger, "Ansible Tower server " + towerServer + " does not exist in Jenkins configuration");
         }
 
         // Apply credential override if provided
@@ -517,6 +523,7 @@ public class AnsibleTowerRunner {
         }
 
         TowerConnector myTowerConnection = towerConfigToRunOn.getTowerConnector();
+        myTowerConnection.setConsole(logger);
 
         // Expand all of the parameters
         String expandedProject = envVars.expand(projectName);
@@ -532,26 +539,29 @@ public class AnsibleTowerRunner {
         }
 
         // Get the project (this will also validates the project exists)
+        milestone(logger, "Resolving project: project=" + expandedProject);
         TowerProject myProject = null;
         try {
             myProject = new TowerProject(expandedProject, myTowerConnection);
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Unable to lookup project: " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Unable to lookup project; revision was not updated: " + e.getMessage());
         }
+        milestone(logger, "Project resolved: project=" + expandedProject);
 
         if (verbose) {
             logger.println("Requesting tower to update " + expandedProject + " revision to " + expandedRevision);
         }
 
         // Update project revision
+        milestone(logger, "Updating project revision: project=" + expandedProject);
         try {
-            return myProject.updateRevision(expandedRevision);
+            boolean updated = myProject.updateRevision(expandedRevision);
+            if(updated) { milestone(logger, "Project revision updated: project=" + expandedProject); }
+            return updated;
         } catch (AnsibleTowerException e) {
-            logger.println("ERROR: Unable to update project revision " + e.getMessage());
             myTowerConnection.releaseToken();
-            return false;
+            return fail(logger, "Unable to update project revision: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerRunner.java
@@ -12,6 +12,8 @@ import hudson.model.Run;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRequestException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerTransientException;
 import org.jenkinsci.plugins.ansible_tower.util.*;
 import org.jenkinsci.plugins.envinject.service.EnvInjectActionSetter;
 
@@ -163,6 +165,10 @@ public class AnsibleTowerRunner {
             template = myTowerConnection.getJobTemplate(expandedJobTemplate, templateType);
         } catch (AnsibleTowerException e) {
             myTowerConnection.releaseToken();
+            if(e instanceof AnsibleTowerRequestException || e instanceof AnsibleTowerTransientException) {
+                return fail(logger, "Job was not launched because the " + templateType
+                    + " template lookup request failed");
+            }
             return fail(logger, "Unable to lookup job template; the job was not launched: " + e.getMessage());
         }
         milestone(logger, "Job template resolved: templateId=" + template.getLong("id"));

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerStep.java
@@ -12,6 +12,7 @@ import hudson.*;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.ansible_tower.util.GetUserPageCredentials;
 import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation;
+import org.jenkinsci.plugins.ansible_tower.util.TowerLogger;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
@@ -299,13 +300,19 @@ public class AnsibleTowerStep extends AbstractStepImpl {
             boolean async = false;
             if(step.getAsync() != null) { async = step.getAsync(); }
             Properties map = new Properties();
-            boolean runResult = runner.runJobTemplate(
-                    listener.getLogger(), step.getTowerServer(), towerCredentialsId, step.getJobTemplate(), jobType, extraVars,
-                    limit, tags, skipTags, inventory, credential, scmBranch, verbose, towerLogLevel, removeColor, envVars,
-                    templateType, importWorkflowChildLogs, ws, run, map, async
-            );
+            boolean runResult;
+            try {
+                runResult = runner.runJobTemplate(
+                        listener.getLogger(), step.getTowerServer(), towerCredentialsId, step.getJobTemplate(), jobType, extraVars,
+                        limit, tags, skipTags, inventory, credential, scmBranch, verbose, towerLogLevel, removeColor, envVars,
+                        templateType, importWorkflowChildLogs, ws, run, map, async
+                );
+            } catch(RuntimeException failure) {
+                throw new AbortException(TowerLogger.reportUnexpected(
+                    listener.getLogger(), "Ansible Tower job template operation", failure));
+            }
             if(!runResult && throwExceptionWhenFail) {
-                throw new AbortException("Ansible Tower build step failed");
+                throw new AbortException(runner.getLastFailureMessage());
             }
             return map;
         }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTowerStep.java
@@ -309,7 +309,7 @@ public class AnsibleTowerStep extends AbstractStepImpl {
                 );
             } catch(RuntimeException failure) {
                 throw new AbortException(TowerLogger.reportUnexpected(
-                    listener.getLogger(), "Ansible Tower job template operation", failure));
+                    "Ansible Tower job template operation", failure));
             }
             if(!runResult && throwExceptionWhenFail) {
                 throw new AbortException(runner.getLastFailureMessage());

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerRequestException.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerRequestException.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.ansible_tower.exceptions;
 
 /** A request failure whose HTTP or transport diagnostics were already written to the build console. */
-public class AnsibleTowerRequestException extends AnsibleTowerException {
+public class AnsibleTowerRequestException extends AnsibleTowerException implements ConsoleDiagnosedException {
     private static final long serialVersionUID = 1L;
 
     public AnsibleTowerRequestException(String message) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerRequestException.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerRequestException.java
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.ansible_tower.exceptions;
+
+/** A request failure whose HTTP or transport diagnostics were already written to the build console. */
+public class AnsibleTowerRequestException extends AnsibleTowerException {
+    private static final long serialVersionUID = 1L;
+
+    public AnsibleTowerRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerTransientException.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/AnsibleTowerTransientException.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.ansible_tower.exceptions;
 
-public class AnsibleTowerTransientException extends AnsibleTowerException {
+public class AnsibleTowerTransientException extends AnsibleTowerException implements ConsoleDiagnosedException {
     private final int statusCode;
 
     public AnsibleTowerTransientException(String message, int statusCode) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/ConsoleDiagnosedException.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/exceptions/ConsoleDiagnosedException.java
@@ -1,0 +1,5 @@
+package org.jenkinsci.plugins.ansible_tower.exceptions;
+
+/** Marks a failure whose technical diagnostics have already been written to the build console. */
+public interface ConsoleDiagnosedException {
+}

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -602,10 +602,8 @@ public class TowerConnector implements Serializable {
         } catch(AnsibleTowerItemDoesNotExist atidne) {
             String ucTemplateType = templateType.replaceFirst(templateType.substring(0,1), templateType.substring(0,1).toUpperCase());
             throw new AnsibleTowerException(ucTemplateType +" template does not exist in tower");
-        } catch(AnsibleTowerRequestException | AnsibleTowerTransientException requestFailure) {
-            throw requestFailure;
         } catch(AnsibleTowerException ate) {
-            throw new AnsibleTowerException("Unable to find "+ templateType +" template: "+ ate.getMessage());
+            throw new AnsibleTowerException("Unable to find "+ templateType +" template: "+ ate.getMessage(), ate);
         }
 
         // Now get the job template so we can check the options being passed in
@@ -816,7 +814,7 @@ public class TowerConnector implements Serializable {
                 throw new AnsibleTowerException("Tower received a bad request (400 response code)");
             }
         } else {
-            throw new AnsibleTowerException("Unexpected error code returned ("
+            throw new AnsibleTowerRequestException("Unexpected error code returned ("
                 + response.getStatusLine().getStatusCode() + ")");
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -530,6 +530,7 @@ public class TowerConnector implements Serializable {
             Integer.parseInt(idToCheck);
             // We got an ID so lets see if we can load that item
             HttpResponse response = makeRequest(GET, api_endpoint + idToCheck +"/");
+            requireSuccessfulLookup(response, api_endpoint + idToCheck + "/");
             JSONObject responseObject;
             try {
                 responseObject = JSONObject.fromObject(EntityUtils.toString(response.getEntity()));
@@ -549,6 +550,7 @@ public class TowerConnector implements Serializable {
             } catch(UnsupportedEncodingException e) {
                 throw new AnsibleTowerException("Unable to encode item name for lookup");
             }
+            requireSuccessfulLookup(response, api_endpoint + "?name=<redacted>");
 
             JSONObject responseObject;
             try {
@@ -571,6 +573,15 @@ public class TowerConnector implements Serializable {
                 JSONObject foundItem = (JSONObject) responseObject.getJSONArray("results").get(0);
                 return foundItem;
             }
+        }
+    }
+
+    private void requireSuccessfulLookup(HttpResponse response, String endpoint) throws AnsibleTowerException {
+        int statusCode = response.getStatusLine().getStatusCode();
+        if(statusCode != 200) {
+            EntityUtils.consumeQuietly(response.getEntity());
+            throw new AnsibleTowerException("GET " + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+                + " returned HTTP " + statusCode);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -109,6 +109,7 @@ public class TowerConnector implements Serializable {
     public void setDebug(boolean debug) {
         logger.setDebugging(debug);
     }
+    public void setConsole(PrintStream console) { logger.setConsole(console); }
     public void setRemoveColor(boolean removeColor) { this.removeColor = removeColor;}
     public void setGetWorkflowChildLogs(boolean importChildWorkflowLogs) { this.importChildWorkflowLogs = importChildWorkflowLogs; }
     public void setGetFullLogs(boolean getFullLogs) { this.getFullLogs = getFullLogs; }
@@ -361,22 +362,39 @@ public class TowerConnector implements Serializable {
 
         DefaultHttpClient httpClient = getHttpClient();
         HttpResponse response;
+        long requestStarted = System.nanoTime();
         try {
             response = httpClient.execute(request);
         } catch(Exception e) {
+            long durationMs = (System.nanoTime() - requestStarted) / 1_000_000L;
+            String failure = "HTTP request failed: method=" + getMethodName(requestType)
+                + ", endpoint=" + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+                + ", exception=" + e.getClass().getSimpleName() + ", durationMs=" + durationMs;
+            logger.consoleError(failure);
+            if(requestType == POST && isOutcomeUncertainEndpoint(endpoint)) {
+                logger.consoleWarning(unknownOutcomeMessage(endpoint,
+                    "Jenkins did not receive a response"));
+            }
             if(isTransientTransportFailure(e)) {
                 throw new AnsibleTowerTransientException("Transient Tower transport failure: method="
-                    + getMethodName(requestType) + ", endpoint=" + buildEndpoint(endpoint)
+                    + getMethodName(requestType) + ", endpoint="
+                    + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
                     + ", cause=" + e.getClass().getSimpleName(), e);
             }
             throw new AnsibleTowerException("Unable to make tower request: "+ e.getMessage());
         }
 
         int statusCode = response.getStatusLine().getStatusCode();
+        long durationMs = (System.nanoTime() - requestStarted) / 1_000_000L;
         String responseMetadata = "HTTP request completed: method=" + getMethodName(requestType)
-            + ", endpoint=" + buildEndpoint(endpoint) + ", httpStatus=" + statusCode;
+            + ", endpoint=" + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+            + ", httpStatus=" + statusCode + ", durationMs=" + durationMs;
         if(statusCode >= 400) {
-            logger.warning(responseMetadata);
+            logger.consoleError(responseMetadata);
+            if(requestType == POST && isOutcomeUncertainEndpoint(endpoint) && isTransientGatewayStatus(statusCode)) {
+                logger.consoleWarning(unknownOutcomeMessage(endpoint,
+                    "Jenkins received HTTP " + statusCode));
+            }
         } else {
             logger.debug(responseMetadata);
         }
@@ -402,6 +420,18 @@ public class TowerConnector implements Serializable {
         }
 
         return response;
+    }
+
+    static boolean isOutcomeUncertainEndpoint(String endpoint) {
+        return endpoint != null && (endpoint.contains("/launch/") || endpoint.endsWith("/update/"));
+    }
+
+    static String unknownOutcomeMessage(String endpoint, String responseFailure) {
+        boolean launch = endpoint != null && endpoint.contains("/launch/");
+        String operation = launch ? "launch" : "project sync";
+        String resource = launch ? "job" : "sync";
+        return "Tower " + operation + " outcome is unknown; the controller may have created the "
+            + resource + ", but " + responseFailure + ". Automatic retry was not performed.";
     }
 
     static boolean isTransientTransportFailure(Throwable failure) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -412,8 +412,8 @@ public class TowerConnector implements Serializable {
                 if(responseObject.containsKey("detail")) {
                     exceptionText+= ": "+ responseObject.getString("detail");
                 }
-            } catch (IOException ioe) {
-                // Ignore if we get an error
+            } catch (IOException | RuntimeException ignored) {
+                // Keep the generic forbidden message when the error body is not valid JSON.
             }
 
             throw new AnsibleTowerException(exceptionText);

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -11,6 +11,7 @@ import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerDoesNotSupport
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRefusesToGiveToken;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerTransientException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRequestException;
 
 import java.io.*;
 import java.net.URI;
@@ -385,7 +386,8 @@ public class TowerConnector implements Serializable {
 
         int statusCode = response.getStatusLine().getStatusCode();
         long durationMs = (System.nanoTime() - requestStarted) / 1_000_000L;
-        String responseMetadata = "HTTP request completed: method=" + getMethodName(requestType)
+        String responseMetadata = "HTTP request " + (statusCode >= 400 ? "failed" : "completed")
+            + ": method=" + getMethodName(requestType)
             + ", url=" + TowerLogger.sanitizeUrl(myURI.toString())
             + ", httpStatus=" + statusCode + ", durationMs=" + durationMs;
         if(statusCode >= 400) {
@@ -579,7 +581,7 @@ public class TowerConnector implements Serializable {
         int statusCode = response.getStatusLine().getStatusCode();
         if(statusCode != 200) {
             EntityUtils.consumeQuietly(response.getEntity());
-            throw new AnsibleTowerException("GET " + TowerLogger.sanitizeUrl(url + buildEndpoint(endpoint))
+            throw new AnsibleTowerRequestException("GET " + TowerLogger.sanitizeUrl(url + buildEndpoint(endpoint))
                 + " returned HTTP " + statusCode);
         }
     }
@@ -600,6 +602,8 @@ public class TowerConnector implements Serializable {
         } catch(AnsibleTowerItemDoesNotExist atidne) {
             String ucTemplateType = templateType.replaceFirst(templateType.substring(0,1), templateType.substring(0,1).toUpperCase());
             throw new AnsibleTowerException(ucTemplateType +" template does not exist in tower");
+        } catch(AnsibleTowerRequestException | AnsibleTowerTransientException requestFailure) {
+            throw requestFailure;
         } catch(AnsibleTowerException ate) {
             throw new AnsibleTowerException("Unable to find "+ templateType +" template: "+ ate.getMessage());
         }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnector.java
@@ -368,7 +368,7 @@ public class TowerConnector implements Serializable {
         } catch(Exception e) {
             long durationMs = (System.nanoTime() - requestStarted) / 1_000_000L;
             String failure = "HTTP request failed: method=" + getMethodName(requestType)
-                + ", endpoint=" + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+                + ", url=" + TowerLogger.sanitizeUrl(myURI.toString())
                 + ", exception=" + e.getClass().getSimpleName() + ", durationMs=" + durationMs;
             logger.consoleError(failure);
             if(requestType == POST && isOutcomeUncertainEndpoint(endpoint)) {
@@ -377,8 +377,7 @@ public class TowerConnector implements Serializable {
             }
             if(isTransientTransportFailure(e)) {
                 throw new AnsibleTowerTransientException("Transient Tower transport failure: method="
-                    + getMethodName(requestType) + ", endpoint="
-                    + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+                    + getMethodName(requestType) + ", url=" + TowerLogger.sanitizeUrl(myURI.toString())
                     + ", cause=" + e.getClass().getSimpleName(), e);
             }
             throw new AnsibleTowerException("Unable to make tower request: "+ e.getMessage());
@@ -387,7 +386,7 @@ public class TowerConnector implements Serializable {
         int statusCode = response.getStatusLine().getStatusCode();
         long durationMs = (System.nanoTime() - requestStarted) / 1_000_000L;
         String responseMetadata = "HTTP request completed: method=" + getMethodName(requestType)
-            + ", endpoint=" + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+            + ", url=" + TowerLogger.sanitizeUrl(myURI.toString())
             + ", httpStatus=" + statusCode + ", durationMs=" + durationMs;
         if(statusCode >= 400) {
             logger.consoleError(responseMetadata);
@@ -580,7 +579,7 @@ public class TowerConnector implements Serializable {
         int statusCode = response.getStatusLine().getStatusCode();
         if(statusCode != 200) {
             EntityUtils.consumeQuietly(response.getEntity());
-            throw new AnsibleTowerException("GET " + TowerLogger.sanitizeEndpoint(buildEndpoint(endpoint))
+            throw new AnsibleTowerException("GET " + TowerLogger.sanitizeUrl(url + buildEndpoint(endpoint))
                 + " returned HTTP " + statusCode);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
@@ -6,14 +6,26 @@ package org.jenkinsci.plugins.ansible_tower.util;
  */
 
 import java.io.Serializable;
+import java.io.PrintStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class TowerLogger implements Serializable {
+    private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = Logger.getLogger(TowerLogger.class.getName());
     private static final String PREFIX = "[Ansible-Tower] ";
 
     private boolean debugging = false;
+    private transient PrintStream console;
+
+    public TowerLogger() {
+    }
+
+    public TowerLogger(PrintStream console) {
+        this.console = console;
+    }
+
+    public void setConsole(PrintStream console) { this.console = console; }
     public void setDebugging(boolean debugging) { this.debugging = debugging; }
 
     /**
@@ -42,8 +54,63 @@ public class TowerLogger implements Serializable {
         log(Level.SEVERE, message);
     }
 
+    public void consoleInfo(String message) {
+        writeConsole("INFO", message);
+    }
+
+    public void consoleWarning(String message) {
+        String safeMessage = sanitizeMessage(message);
+        warning(safeMessage);
+        writeConsole("WARNING", safeMessage);
+    }
+
+    public void consoleError(String message) {
+        String safeMessage = sanitizeMessage(message);
+        severe(safeMessage);
+        writeConsole("ERROR", safeMessage);
+    }
+
+    private void writeConsole(String level, String message) {
+        if(console != null) {
+            console.println(PREFIX + level + ": " + sanitizeMessage(message));
+        }
+    }
+
+    public static String sanitizeEndpoint(String endpoint) {
+        if(endpoint == null) { return "unknown"; }
+        int query = endpoint.indexOf('?');
+        if(query < 0) { return endpoint; }
+        StringBuilder sanitized = new StringBuilder(endpoint.substring(0, query));
+        String[] parameters = endpoint.substring(query + 1).split("&");
+        for(int i = 0; i < parameters.length; i++) {
+            String name = parameters[i];
+            int equals = name.indexOf('=');
+            if(equals >= 0) { name = name.substring(0, equals); }
+            sanitized.append(i == 0 ? '?' : '&').append(name).append("=<redacted>");
+        }
+        return sanitized.toString();
+    }
+
+    public static String sanitizeMessage(String message) {
+        if(message == null) { return "unknown error"; }
+        return message
+            .replaceAll("(?i)(authorization|password|token|credential|extra_vars)=[^,\\s]+", "$1=<redacted>")
+            .replaceAll("([?&][^=,\\s]+)=([^&,\\s]+)", "$1=<redacted>");
+    }
+
     public static void writeMessage(String message) {
         log(Level.INFO, message);
+    }
+
+    public static String reportUnexpected(PrintStream console, String operation, RuntimeException failure) {
+        String detail = operation + " failed unexpectedly: exception="
+            + failure.getClass().getSimpleName() + ", message=" + sanitizeMessage(failure.getMessage());
+        LOGGER.log(Level.SEVERE, PREFIX + detail, failure);
+        if(console != null) {
+            console.println(PREFIX + "ERROR: " + detail
+                + ". See the Jenkins System Log for the full stack trace.");
+        }
+        return detail;
     }
 
     private static void log(Level level, String message) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
@@ -7,6 +7,8 @@ package org.jenkinsci.plugins.ansible_tower.util;
 
 import java.io.Serializable;
 import java.io.PrintStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -89,6 +91,19 @@ public class TowerLogger implements Serializable {
             sanitized.append(i == 0 ? '?' : '&').append(name).append("=<redacted>");
         }
         return sanitized.toString();
+    }
+
+    public static String sanitizeUrl(String value) {
+        if(value == null) { return "unknown"; }
+        try {
+            URI uri = new URI(value);
+            if(!uri.isAbsolute()) { return sanitizeEndpoint(value); }
+            URI withoutUserInfo = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(),
+                uri.getPath(), uri.getQuery(), null);
+            return sanitizeEndpoint(withoutUserInfo.toString());
+        } catch(URISyntaxException invalidUrl) {
+            return sanitizeEndpoint(value.replaceFirst("(?<=//)[^/@]+@", "<redacted>@"));
+        }
     }
 
     public static String sanitizeMessage(String message) {

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerLogger.java
@@ -102,14 +102,14 @@ public class TowerLogger implements Serializable {
         log(Level.INFO, message);
     }
 
-    public static String reportUnexpected(PrintStream console, String operation, RuntimeException failure) {
+    public static String reportUnexpected(String operation, RuntimeException failure) {
         String detail = operation + " failed unexpectedly: exception="
-            + failure.getClass().getSimpleName() + ", message=" + sanitizeMessage(failure.getMessage());
-        LOGGER.log(Level.SEVERE, PREFIX + detail, failure);
-        if(console != null) {
-            console.println(PREFIX + "ERROR: " + detail
-                + ". See the Jenkins System Log for the full stack trace.");
-        }
+            + failure.getClass().getSimpleName()
+            + ". See the Jenkins System Log for the sanitized stack trace.";
+        RuntimeException sanitizedFailure = new RuntimeException(
+            failure.getClass().getSimpleName() + " during " + operation);
+        sanitizedFailure.setStackTrace(failure.getStackTrace());
+        LOGGER.log(Level.SEVERE, PREFIX + detail, sanitizedFailure);
         return detail;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProject.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProject.java
@@ -5,6 +5,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerItemDoesNotExist;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRequestException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -29,7 +30,7 @@ public class TowerProject implements Serializable {
         } catch(AnsibleTowerItemDoesNotExist atidne) {
             throw new AnsibleTowerException("Project "+ projectName +" does not exist in tower");
         } catch(AnsibleTowerException ate) {
-            throw new AnsibleTowerException("Unable to find project "+ projectName +": "+ ate.getMessage());
+            throw new AnsibleTowerException("Unable to find project "+ projectName +": "+ ate.getMessage(), ate);
         }
 
         // Now that we have an ID, get the project from its ID.
@@ -37,10 +38,10 @@ public class TowerProject implements Serializable {
         try {
             response = myConnector.makeRequest(myConnector.GET, apiEndPoint + projectID + "/", null, false);
         } catch(AnsibleTowerException e) {
-            throw new AnsibleTowerException("Failed to load project information for "+ projectName +": "+ e.getMessage());
+            throw new AnsibleTowerException("Failed to load project information for "+ projectName +": "+ e.getMessage(), e);
         }
         if (response.getStatusLine().getStatusCode() != 200) {
-            throw new AnsibleTowerException("Unexpected error code returned when getting project (" + response.getStatusLine().getStatusCode() + ")");
+            throw new AnsibleTowerRequestException("Unexpected error code returned when getting project (" + response.getStatusLine().getStatusCode() + ")");
         }
         try {
             String json = EntityUtils.toString(response.getEntity());
@@ -63,7 +64,7 @@ public class TowerProject implements Serializable {
             HttpResponse response = myConnector.makeRequest(myConnector.GET, projectData.getJSONObject("related").getString("update"), null, false);
 
             if (response.getStatusLine().getStatusCode() != 200) {
-                throw new AnsibleTowerException("Unexpected error code return when getting project update (" + response.getStatusLine().getStatusCode() + ")");
+                throw new AnsibleTowerRequestException("Unexpected error code return when getting project update (" + response.getStatusLine().getStatusCode() + ")");
             }
             try {
                 this.updateResponse = JSONObject.fromObject(EntityUtils.toString(response.getEntity()));
@@ -85,10 +86,10 @@ public class TowerProject implements Serializable {
         try {
             response = myConnector.makeRequest(myConnector.PATCH, finalEndPoint, patchBody, false);
         } catch(AnsibleTowerException e) {
-            throw new AnsibleTowerException("Failed to update project revision for "+ projectName +": "+ e.getMessage());
+            throw new AnsibleTowerException("Failed to update project revision for "+ projectName +": "+ e.getMessage(), e);
         }
         if (response.getStatusLine().getStatusCode() != 200) {
-            throw new AnsibleTowerException("Unexpected response code returned when updating project (" + response.getStatusLine().getStatusCode() + ")");
+            throw new AnsibleTowerRequestException("Unexpected response code returned when updating project (" + response.getStatusLine().getStatusCode() + ")");
         }
 
         // If we made it down here we were successful so we can return

--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProjectSync.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/util/TowerProjectSync.java
@@ -4,6 +4,7 @@ import net.sf.json.JSONObject;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRequestException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -22,7 +23,7 @@ public class TowerProjectSync implements Serializable {
 
         HttpResponse response = connection.makeRequest(connection.POST, projectReference.getProjectSyncURL(), null, false);
         if (response.getStatusLine().getStatusCode() != 202 && response.getStatusLine().getStatusCode() != 200) {
-            throw new AnsibleTowerException("Unexpected error code returned when launching project sync (" + response.getStatusLine().getStatusCode() + ")");
+            throw new AnsibleTowerRequestException("Unexpected error code returned when launching project sync (" + response.getStatusLine().getStatusCode() + ")");
         }
         try {
             String json = EntityUtils.toString(response.getEntity());
@@ -35,7 +36,7 @@ public class TowerProjectSync implements Serializable {
     private void loadSync(int method)  throws AnsibleTowerException {
         HttpResponse response = this.connection.makeRequest(method, syncData.getString("url"), null, false);
         if (response.getStatusLine().getStatusCode() != 200) {
-            throw new AnsibleTowerException("Unexpected error code returned when loading project sync (" + response.getStatusLine().getStatusCode() + ")");
+            throw new AnsibleTowerRequestException("Unexpected error code returned when loading project sync (" + response.getStatusLine().getStatusCode() + ")");
         }
         try {
             String json = EntityUtils.toString(response.getEntity());

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
@@ -6,7 +6,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 import hudson.model.FreeStyleProject;
+import hudson.EnvVars;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Properties;
 import jenkins.model.Jenkins;
 import org.apache.http.client.HttpClient;
 import org.jenkinsci.plugins.ansible_tower.util.TowerConnector;
@@ -64,6 +69,25 @@ public class PluginCompatibilityTest {
         assertThat(revision.getRevision(), is("main"));
         assertThat(revision.getVerbose(), is(true));
         assertThat(revision.getThrowExceptionWhenFail(), is(false));
+    }
+
+    @Test
+    public void runnerWritesMilestoneAndPreservesFailureForPipelineBoundary(JenkinsRule jenkinsRule) {
+        AnsibleTowerGlobalConfig.get().setTowerInstallation(List.of());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        AnsibleTowerRunner runner = new AnsibleTowerRunner();
+
+        boolean result = runner.runJobTemplate(
+            new PrintStream(output, true, StandardCharsets.UTF_8), "missing-tower", "", "deploy", "run",
+            "", "", "", "", "", "", "", false, "false", false, new EnvVars(),
+            "job", false, null, null, new Properties(), false);
+
+        assertThat(result, is(false));
+        assertThat(runner.getLastFailureMessage(),
+            is("Ansible Tower server missing-tower does not exist in Jenkins configuration"));
+        String console = output.toString(StandardCharsets.UTF_8);
+        assertThat(console.contains("[Ansible-Tower] INFO: Starting job template operation"), is(true));
+        assertThat(console.contains("[Ansible-Tower] ERROR: Ansible Tower server missing-tower"), is(true));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
@@ -16,6 +16,8 @@ import jenkins.model.Jenkins;
 import org.apache.http.client.HttpClient;
 import org.jenkinsci.plugins.ansible_tower.util.TowerConnector;
 import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerRequestException;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -88,6 +90,16 @@ public class PluginCompatibilityTest {
         String console = output.toString(StandardCharsets.UTF_8);
         assertThat(console.contains("[Ansible-Tower] INFO: Starting job template operation"), is(true));
         assertThat(console.contains("[Ansible-Tower] ERROR: Ansible Tower server missing-tower"), is(true));
+    }
+
+    @Test
+    public void runnerRecognizesConsoleDiagnosticsThroughWrappedCauses() {
+        AnsibleTowerException diagnosed = new AnsibleTowerException("template lookup failed",
+            new AnsibleTowerRequestException("GET returned HTTP 503"));
+        AnsibleTowerException undiagnosed = new AnsibleTowerException("invalid template configuration");
+
+        assertThat(AnsibleTowerRunner.hasConsoleDiagnostics(diagnosed), is(true));
+        assertThat(AnsibleTowerRunner.hasConsoleDiagnostics(undiagnosed), is(false));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -20,6 +20,7 @@ import org.apache.http.conn.params.ConnManagerParams;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.jenkinsci.plugins.ansible_tower.exceptions.AnsibleTowerException;
 
 class TowerConnectorTest {
 
@@ -127,6 +128,36 @@ class TowerConnectorTest {
             MatcherAssert.assertThat(console, CoreMatchers.containsString("name=<redacted>"));
             MatcherAssert.assertThat(console.contains("private-template"), CoreMatchers.is(false));
             MatcherAssert.assertThat(console.contains("test-token"), CoreMatchers.is(false));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void htmlGatewayFailure_isNotParsedOrCopiedIntoConsoleException() throws Exception {
+        String html = "<html><style>secret-route-style</style><h1>Application is not available</h1></html>";
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v2/ping/", exchange -> respond(exchange, "{\"version\":\"3.8.0\"}"));
+        server.createContext("/api/v2/workflow_job_templates/8/",
+            exchange -> respond(exchange, 503, html));
+        server.start();
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            TowerConnector connector = new TowerConnector(
+                "http://127.0.0.1:" + server.getAddress().getPort(), null, null,
+                "test-token", false, false);
+            connector.setConsole(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+            AnsibleTowerException failure = org.junit.jupiter.api.Assertions.assertThrows(
+                AnsibleTowerException.class,
+                () -> connector.getJobTemplate("8", TowerConnector.WORKFLOW_TEMPLATE_TYPE));
+
+            MatcherAssert.assertThat(failure.getMessage(), CoreMatchers.containsString("returned HTTP 503"));
+            MatcherAssert.assertThat(failure.getMessage().contains("<html>"), CoreMatchers.is(false));
+            String console = output.toString(StandardCharsets.UTF_8);
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=503"));
+            MatcherAssert.assertThat(console.contains("<html>"), CoreMatchers.is(false));
+            MatcherAssert.assertThat(console.contains("secret-route-style"), CoreMatchers.is(false));
         } finally {
             server.stop(0);
         }

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -123,6 +123,9 @@ class TowerConnectorTest {
 
             String console = output.toString(StandardCharsets.UTF_8);
             MatcherAssert.assertThat(console, CoreMatchers.containsString("method=GET"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString(
+                "url=http://127.0.0.1:" + server.getAddress().getPort()
+                    + "/api/v2/job_templates/?name=<redacted>"));
             MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=502"));
             MatcherAssert.assertThat(console, CoreMatchers.containsString("durationMs="));
             MatcherAssert.assertThat(console, CoreMatchers.containsString("name=<redacted>"));
@@ -189,6 +192,9 @@ class TowerConnectorTest {
 
             String console = output.toString(StandardCharsets.UTF_8);
             MatcherAssert.assertThat(console, CoreMatchers.containsString("method=POST"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString(
+                "url=http://127.0.0.1:" + server.getAddress().getPort()
+                    + "/api/v2/job_templates/12/launch/"));
             MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=502"));
             MatcherAssert.assertThat(console, CoreMatchers.containsString("launch outcome is unknown"));
             MatcherAssert.assertThat(console, CoreMatchers.containsString("Automatic retry was not performed"));

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -134,30 +134,35 @@ class TowerConnectorTest {
     }
 
     @Test
-    public void htmlGatewayFailure_isNotParsedOrCopiedIntoConsoleException() throws Exception {
+    public void nonSuccessLookupResponses_areNotParsedOrCopiedIntoConsoleException() throws Exception {
         String html = "<html><style>secret-route-style</style><h1>Application is not available</h1></html>";
+        AtomicInteger responseStatus = new AtomicInteger(503);
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/api/v2/ping/", exchange -> respond(exchange, "{\"version\":\"3.8.0\"}"));
         server.createContext("/api/v2/workflow_job_templates/8/",
-            exchange -> respond(exchange, 503, html));
+            exchange -> respond(exchange, responseStatus.get(), html));
         server.start();
         try {
-            ByteArrayOutputStream output = new ByteArrayOutputStream();
-            TowerConnector connector = new TowerConnector(
-                "http://127.0.0.1:" + server.getAddress().getPort(), null, null,
-                "test-token", false, false);
-            connector.setConsole(new PrintStream(output, true, StandardCharsets.UTF_8));
+            int[] representativeStatuses = {400, 401, 403, 404, 429, 500, 502, 503, 504};
+            for(int status : representativeStatuses) {
+                responseStatus.set(status);
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                TowerConnector connector = new TowerConnector(
+                    "http://127.0.0.1:" + server.getAddress().getPort(), null, null,
+                    "test-token", false, false);
+                connector.setConsole(new PrintStream(output, true, StandardCharsets.UTF_8));
 
-            AnsibleTowerException failure = org.junit.jupiter.api.Assertions.assertThrows(
-                AnsibleTowerException.class,
-                () -> connector.getJobTemplate("8", TowerConnector.WORKFLOW_TEMPLATE_TYPE));
+                AnsibleTowerException failure = org.junit.jupiter.api.Assertions.assertThrows(
+                    AnsibleTowerException.class,
+                    () -> connector.getJobTemplate("8", TowerConnector.WORKFLOW_TEMPLATE_TYPE));
 
-            MatcherAssert.assertThat(failure.getMessage(), CoreMatchers.containsString("returned HTTP 503"));
-            MatcherAssert.assertThat(failure.getMessage().contains("<html>"), CoreMatchers.is(false));
-            String console = output.toString(StandardCharsets.UTF_8);
-            MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=503"));
-            MatcherAssert.assertThat(console.contains("<html>"), CoreMatchers.is(false));
-            MatcherAssert.assertThat(console.contains("secret-route-style"), CoreMatchers.is(false));
+                MatcherAssert.assertThat(failure.getMessage().contains("<html>"), CoreMatchers.is(false));
+                MatcherAssert.assertThat(failure.getMessage().contains("secret-route-style"), CoreMatchers.is(false));
+                String console = output.toString(StandardCharsets.UTF_8);
+                MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=" + status));
+                MatcherAssert.assertThat(console.contains("<html>"), CoreMatchers.is(false));
+                MatcherAssert.assertThat(console.contains("secret-route-style"), CoreMatchers.is(false));
+            }
         } finally {
             server.stop(0);
         }

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerConnectorTest.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.ansible_tower.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
@@ -91,11 +93,83 @@ class TowerConnectorTest {
     }
 
     private static void respond(HttpExchange exchange, String body) throws IOException {
+        respond(exchange, 200, body);
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
         byte[] response = body.getBytes(StandardCharsets.UTF_8);
-        exchange.sendResponseHeaders(200, response.length);
+        exchange.sendResponseHeaders(status, response.length);
         try(OutputStream output = exchange.getResponseBody()) {
             output.write(response);
         }
+    }
+
+    @Test
+    public void failedGet_writesSanitizedOperationalMetadataToBuildConsole() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v2/ping/", exchange -> respond(exchange, "{\"version\":\"3.8.0\"}"));
+        server.createContext("/api/v2/job_templates/", exchange -> respond(exchange, 502, "gateway failure"));
+        server.start();
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            TowerConnector connector = new TowerConnector(
+                "http://127.0.0.1:" + server.getAddress().getPort(), null, null,
+                "test-token", false, false);
+            connector.setConsole(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+            connector.makeRequest(TowerConnector.GET,
+                "/job_templates/?name=private-template", null, false);
+
+            String console = output.toString(StandardCharsets.UTF_8);
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("method=GET"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=502"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("durationMs="));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("name=<redacted>"));
+            MatcherAssert.assertThat(console.contains("private-template"), CoreMatchers.is(false));
+            MatcherAssert.assertThat(console.contains("test-token"), CoreMatchers.is(false));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void transientLaunchResponse_warnsThatOutcomeIsUnknownWithoutLoggingBody() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v2/ping/", exchange -> respond(exchange, "{\"version\":\"3.8.0\"}"));
+        server.createContext("/api/v2/job_templates/12/launch/",
+            exchange -> respond(exchange, 502, "gateway failure"));
+        server.start();
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            TowerConnector connector = new TowerConnector(
+                "http://127.0.0.1:" + server.getAddress().getPort(), null, null,
+                "test-token", false, false);
+            connector.setConsole(new PrintStream(output, true, StandardCharsets.UTF_8));
+            JSONObject body = new JSONObject();
+            body.put("extra_vars", "TOP_SECRET_VALUE");
+
+            connector.makeRequest(TowerConnector.POST,
+                "/job_templates/12/launch/", body, false);
+
+            String console = output.toString(StandardCharsets.UTF_8);
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("method=POST"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("httpStatus=502"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("launch outcome is unknown"));
+            MatcherAssert.assertThat(console, CoreMatchers.containsString("Automatic retry was not performed"));
+            MatcherAssert.assertThat(console.contains("TOP_SECRET_VALUE"), CoreMatchers.is(false));
+            MatcherAssert.assertThat(console.contains("test-token"), CoreMatchers.is(false));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void projectSyncPost_isClassifiedAsHavingAnUncertainOutcome() {
+        MatcherAssert.assertThat(
+            TowerConnector.isOutcomeUncertainEndpoint("/projects/12/update/"), CoreMatchers.is(true));
+        MatcherAssert.assertThat(
+            TowerConnector.unknownOutcomeMessage("/projects/12/update/", "Jenkins received HTTP 503"),
+            CoreMatchers.containsString("project sync outcome is unknown"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
@@ -5,6 +5,9 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.logging.Handler;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -85,6 +88,43 @@ class TowerLoggerTest {
         TowerLogger.writeMessage("connection test");
 
         assertThat(handler.record.getLevel(), is(Level.INFO));
+    }
+
+    @Test
+    void consoleMessages_areVisibleWithoutDebuggingAndUseConsistentSeverity() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TowerLogger towerLogger = new TowerLogger(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+        towerLogger.consoleInfo("resolving template");
+        towerLogger.consoleWarning("gateway unavailable");
+        towerLogger.consoleError("lookup failed");
+
+        String console = output.toString(StandardCharsets.UTF_8);
+        assertThat(console.contains("[Ansible-Tower] INFO: resolving template"), is(true));
+        assertThat(console.contains("[Ansible-Tower] WARNING: gateway unavailable"), is(true));
+        assertThat(console.contains("[Ansible-Tower] ERROR: lookup failed"), is(true));
+    }
+
+    @Test
+    void sanitizers_removeQueryValuesAndCredentialMaterial() {
+        assertThat(TowerLogger.sanitizeEndpoint(
+            "/api/controller/v2/job_templates/?name=private-template&page=2"),
+            is("/api/controller/v2/job_templates/?name=<redacted>&page=<redacted>"));
+        assertThat(TowerLogger.sanitizeMessage(
+            "authorization=Bearer-secret password=hunter2 token=abc failure"),
+            is("authorization=<redacted> password=<redacted> token=<redacted> failure"));
+    }
+
+    @Test
+    void consoleErrorsAlsoSanitizeTheSystemLogRecord() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TowerLogger towerLogger = new TowerLogger(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+        towerLogger.consoleError("request failed token=secret-value");
+
+        assertThat(handler.record.getParameters(),
+            is(new Object[] {"[Ansible-Tower] ", "request failed token=<redacted>"}));
+        assertThat(output.toString(StandardCharsets.UTF_8).contains("secret-value"), is(false));
     }
 
     private static class RecordingHandler extends Handler {

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
@@ -113,6 +113,9 @@ class TowerLoggerTest {
         assertThat(TowerLogger.sanitizeMessage(
             "authorization=Bearer-secret password=hunter2 token=abc failure"),
             is("authorization=<redacted> password=<redacted> token=<redacted> failure"));
+        assertThat(TowerLogger.sanitizeUrl(
+            "https://user:password@aap.example.com/api/controller/v2/jobs/?name=private"),
+            is("https://aap.example.com/api/controller/v2/jobs/?name=<redacted>"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/util/TowerLoggerTest.java
@@ -127,6 +127,17 @@ class TowerLoggerTest {
         assertThat(output.toString(StandardCharsets.UTF_8).contains("secret-value"), is(false));
     }
 
+    @Test
+    void unexpectedFailuresDoNotCopyRuntimeMessagesIntoSystemDiagnostics() {
+        String detail = TowerLogger.reportUnexpected("template lookup",
+            new IllegalArgumentException("<html>private upstream response</html>"));
+
+        assertThat(detail.contains("<html>"), is(false));
+        assertThat(handler.record.getMessage().contains("<html>"), is(false));
+        assertThat(handler.record.getThrown().getMessage(),
+            is("IllegalArgumentException during template lookup"));
+    }
+
     private static class RecordingHandler extends Handler {
         private LogRecord record;
 


### PR DESCRIPTION
## What changed

- split user-facing build console diagnostics from detailed Jenkins system logging
- add consistent milestones for job templates, project syncs, and project revisions
- record sanitized HTTP method, endpoint, status/exception, and duration on failures
- warn when a transient launch or project-sync POST has an unknown outcome without retrying it
- preserve actionable runner failures in Pipeline `AbortException` messages
- redact query values and credential-like material from both logging destinations
- document the logging model and add regression coverage for visibility and secret safety

## Why

The plugin converted many controller failures into a generic `Ansible Tower build step failed` result. Operators often needed controller-level Jenkins logs to determine whether template lookup, launch, or polling failed, and a lost launch response did not explain that the controller might already have created the job.

## User impact

Build consoles now show the operation in progress and actionable failure metadata without exposing request bodies, extra variables, credentials, authorization headers, passwords, or tokens. Existing Pipeline DSL, return values, retry behavior, and Freestyle behavior remain unchanged.

## Validation

- `mvn test`
- `mvn verify`
- `git diff --check`
