### PR TITLE
Fix importTowerLogs Job DSL binding

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTower.java
+++ b/src/main/java/org/jenkinsci/plugins/ansible_tower/AnsibleTower.java
@@ -67,7 +67,7 @@ public class AnsibleTower extends Builder {
 		this.credential = credential;
 		this.scmBranch = scmBranch;
 		this.verbose = verbose;
-		this.importTowerLogs = importTowerLogs.toString();
+		this.importTowerLogs = normalizeImportTowerLogs(importTowerLogs);
 		this.removeColor = removeColor;
 		this.templateType = templateType;
 		this.importWorkflowChildLogs = importWorkflowChildLogs;
@@ -92,7 +92,7 @@ public class AnsibleTower extends Builder {
 		this.credential = credential;
 		this.scmBranch = scmBranch;
 		this.verbose = verbose;
-		this.importTowerLogs = importTowerLogs;
+		this.importTowerLogs = normalizeImportTowerLogs(importTowerLogs);
 		this.removeColor = removeColor;
 		this.templateType = templateType;
 		this.importWorkflowChildLogs = importWorkflowChildLogs;
@@ -142,15 +142,35 @@ public class AnsibleTower extends Builder {
 	@DataBoundSetter
 	public void setVerbose(Boolean verbose) { this.verbose = verbose; }
 	@DataBoundSetter
-	public void setImportTowerLogs(Boolean importTowerLogs) { this.importTowerLogs = importTowerLogs.toString(); }
-	@DataBoundSetter
-	public void setImportTowerLogs(String importTowerLogs) { this.importTowerLogs = importTowerLogs; }
+	public void setImportTowerLogs(Object importTowerLogs) {
+		this.importTowerLogs = normalizeImportTowerLogs(importTowerLogs);
+	}
 	@DataBoundSetter
 	public void setRemoveColor(Boolean removeColor) { this.removeColor = removeColor; }
 	@DataBoundSetter
 	public void setTemplateType(String templateType) { this.templateType = templateType; }
 	@DataBoundSetter
 	public void setImportWorkflowChildLogs(Boolean importWorkflowChildLogs) { this.importWorkflowChildLogs = importWorkflowChildLogs; }
+
+	static String normalizeImportTowerLogs(Object importTowerLogs) {
+		if (importTowerLogs == null) {
+			return "false";
+		}
+		if (importTowerLogs instanceof Boolean) {
+			return importTowerLogs.toString();
+		}
+		if (importTowerLogs instanceof String) {
+			String value = (String) importTowerLogs;
+			if (value.equals("false") || value.equals("true") || value.equals("vars") || value.equals("full")) {
+				return value;
+			}
+			throw new IllegalArgumentException(
+					"importTowerLogs must be one of: false, true, vars, full; received: " + value);
+		}
+		throw new IllegalArgumentException(
+				"importTowerLogs must be a Boolean, String, or null; received type: "
+						+ importTowerLogs.getClass().getName());
+	}
 
     @Override
     public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener)

--- a/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ansible_tower/PluginCompatibilityTest.java
@@ -4,12 +4,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
 import hudson.model.FreeStyleProject;
 import hudson.EnvVars;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import jenkins.model.Jenkins;
@@ -74,6 +78,62 @@ public class PluginCompatibilityTest {
     }
 
     @Test
+    public void freestyleImportTowerLogsAcceptsJobDslValues() {
+        AnsibleTower builder = freestyleBuilder("false");
+
+        builder.setImportTowerLogs(true);
+        assertThat(builder.getImportTowerLogs(), is("true"));
+        builder.setImportTowerLogs(false);
+        assertThat(builder.getImportTowerLogs(), is("false"));
+        for (String value : List.of("false", "true", "vars", "full")) {
+            builder.setImportTowerLogs(value);
+            assertThat(builder.getImportTowerLogs(), is(value));
+        }
+        builder.setImportTowerLogs(null);
+        assertThat(builder.getImportTowerLogs(), is("false"));
+
+        assertThrows(IllegalArgumentException.class, () -> builder.setImportTowerLogs("verbose"));
+        assertThrows(IllegalArgumentException.class, () -> builder.setImportTowerLogs(1));
+    }
+
+    @Test
+    public void freestyleImportTowerLogsAcceptsBooleanThroughGroovyMethodResolution() {
+        AnsibleTower builder = freestyleBuilder("false");
+        Binding binding = new Binding();
+        binding.setVariable("builder", builder);
+
+        new GroovyShell(binding).evaluate("builder.setImportTowerLogs(true)");
+
+        assertThat(builder.getImportTowerLogs(), is("true"));
+    }
+
+    @Test
+    public void freestyleImportTowerLogsExposesOneUnambiguousDataBoundSetter() {
+        List<java.lang.reflect.Method> setters = Arrays.stream(AnsibleTower.class.getMethods())
+                .filter(method -> method.getName().equals("setImportTowerLogs"))
+                .filter(method -> method.isAnnotationPresent(org.kohsuke.stapler.DataBoundSetter.class))
+                .toList();
+
+        assertThat(setters.size(), is(1));
+        assertThat(setters.get(0).getParameterTypes()[0], is(Object.class));
+    }
+
+    @Test
+    public void legacyFreestyleConstructorDefaultsNullImportTowerLogs() {
+        assertThat(freestyleBuilder((Boolean) null).getImportTowerLogs(), is("false"));
+    }
+
+    private static AnsibleTower freestyleBuilder(Boolean importTowerLogs) {
+        return new AnsibleTower("tower", "template", "credential", "run", "", "", "", "", "", "", "",
+                false, importTowerLogs, false, "job", false);
+    }
+
+    private static AnsibleTower freestyleBuilder(String importTowerLogs) {
+        return new AnsibleTower("tower", "template", "credential", "run", "", "", "", "", "", "", "",
+                false, importTowerLogs, false, "job", false);
+    }
+
+    @Test
     public void runnerWritesMilestoneAndPreservesFailureForPipelineBoundary(JenkinsRule jenkinsRule) {
         AnsibleTowerGlobalConfig.get().setTowerInstallation(List.of());
         ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -112,6 +172,7 @@ public class PluginCompatibilityTest {
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
         project.getBuildersList().add(new AnsibleTowerProjectSyncFreestyle(
                 "tower", "credential", "project", true, true, false));
+        project.getBuildersList().add(freestyleBuilder("full"));
         project = jenkinsRule.configRoundtrip(project);
         AnsibleTowerProjectSyncFreestyle restored = project.getBuildersList()
                 .get(AnsibleTowerProjectSyncFreestyle.class);
@@ -121,6 +182,8 @@ public class PluginCompatibilityTest {
         assertThat(restored.getVerbose(), is(true));
         assertThat(restored.getImportTowerLogs(), is(true));
         assertThat(restored.getRemoveColor(), is(false));
+        AnsibleTower restoredJob = project.getBuildersList().get(AnsibleTower.class);
+        assertThat(restoredJob.getImportTowerLogs(), is("full"));
 
         String xml = Jenkins.XSTREAM2.toXML(installation);
         TowerInstallation restoredInstallation = (TowerInstallation) Jenkins.XSTREAM2.fromXML(xml);


### PR DESCRIPTION
## Summary

- consolidate the overloaded `importTowerLogs` data-bound setters into one Job DSL-compatible entry point
- normalize Boolean, String, and null values consistently in both Freestyle constructors and the setter
- reject unsupported values and types with actionable `IllegalArgumentException` messages
- retain the existing String-backed Freestyle configuration and Pipeline step behavior

## Root cause

The Freestyle builder exposed both Boolean and String `setImportTowerLogs` overloads. Groovy/Job DSL method resolution could select an incompatible overload for `importTowerLogs(true)`, causing a `ClassCastException`, while explicit null values could reach `Boolean.toString()` and cause a `NullPointerException`.

This change keeps the persisted property as a String but accepts the legacy Boolean form, the supported String levels (`false`, `true`, `vars`, and `full`), and null (defaulting to `false`) through one unambiguous setter.

## Compatibility

- Freestyle Jelly field and persisted String values are unchanged.
- Legacy Boolean constructor calls remain supported and are now null-safe.
- Pipeline uses `AnsibleTowerStep` and remains unchanged.
- Invalid strings and unsupported types fail early instead of being silently defaulted.

## Tests

- Boolean and supported String values
- explicit null and invalid inputs
- Groovy method resolution for the Job DSL Boolean form
- a single data-bound setter
- Freestyle Jenkins configuration roundtrip
- existing Pipeline data-bound compatibility

Validation:

- `mvn test`
- `mvn verify`

Addresses JENKINS-75754 and supersedes the implementation proposed in #31 with tests against the current master architecture.
